### PR TITLE
[Chore] Unprotected POST haircuts/events no longer requires JWT

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -125,7 +125,7 @@ func RegisterHaircutEventsRoutes(container *di.Container) func(chi.Router) {
 	return func(r chi.Router) {
 		r.Get("/", h.GetEvents)
 		r.Get("/{id}", h.GetEvent)
-		r.With(middlewares.JWTAuthMiddleware(true)).Post("/", h.CreateEvent)
+		r.Post("/", h.CreateEvent)
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin)).Delete("/{id}", h.DeleteEvent)
 	}
 }


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Removed JWT from the POST method so users can create haircut events
---

# 🧠 Reason for Changes

- Users shouldn't have to log in to get a haircut, users can go to the website and book a haircut using their name number etc

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X ] Backend APIs tested via Postman
- [X ] No server errors (Backend)


---


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->

https://trello.com/c/vjAtcmlY/28-post-haircuts-events-should-not-be-protected-by-jwt
---

