### PR TITLE
[Refactor] Protected staff/logs so the user must be role: Admin to get any logs

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -213,7 +213,7 @@ func RegisterStaffRoutes(container *di.Container) func(chi.Router) {
 
 	return func(r chi.Router) {
 		r.Get("/", staffHandlers.GetStaffs)
-		r.Get("/logs", staffLogsHandlers.GetStaffActivityLogs)
+		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin)).Get("/logs", staffLogsHandlers.GetStaffActivityLogs)
 
 		r.With(middlewares.JWTAuthMiddleware(false)).Put("/{id}", staffHandlers.UpdateStaff)
 		r.With(middlewares.JWTAuthMiddleware(false)).Delete("/{id}", staffHandlers.DeleteStaff)


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- 
- protected staff/logs so only users with role: admin can access it with a valid JWT
- 

---

# 🧠 Reason for Changes

So no one can access our staffs logs and what they are doing. Only admins can.

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
[Example: `https://trello.com/c/your-task-id`](https://trello.com/c/ZYWwIAps/27-get-staffs-logs-needs-to-be-protected-by-jwt)

---
