### PR TITLE
[Bugfix] Fixed the issue with generated models.go

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -602,9 +602,24 @@ func main() {
 
 	seedBuiltInPrograms(ctx, db)
 
-	practiceEvents := seedFakeEvents(ctx, db, []string{"Practice"}, locations, true)
+	rows, err := db.QueryContext(ctx, `SELECT type FROM program.programs`)
+	if err != nil {
+		log.Fatalf("Failed to query program types: %v", err)
+	}
+	defer rows.Close()
 
-	courseEvents := seedFakeEvents(ctx, db, []string{"Course"}, locations, true)
+	log.Println("Available program types in DB:")
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			log.Fatalf("Failed to scan type: %v", err)
+		}
+		log.Println("-", t)
+	}
+
+	practiceEvents := seedFakeEvents(ctx, db, []string{"practice"}, locations, true)
+
+	courseEvents := seedFakeEvents(ctx, db, []string{"course"}, locations, true)
 
 	var allEventIds []uuid.UUID
 	allEventIds = append(allEventIds, practiceEvents...)

--- a/cmd/seed/sqlc/generated/event.sql.go
+++ b/cmd/seed/sqlc/generated/event.sql.go
@@ -56,25 +56,34 @@ func (q *Queries) InsertCustomersEnrollments(ctx context.Context, arg InsertCust
 }
 
 const insertEvents = `-- name: InsertEvents :many
-WITH events_data AS (SELECT unnest($1::timestamptz[])     as start_at,
-                            unnest($2::timestamptz[])       as end_at,
-                            unnest($3::varchar[]) as program_name,
-                            unnest($4::varchar[])    as location_name,
-                            unnest($5::varchar[]) AS created_by_email,
-                            unnest($6::varchar[]) AS updated_by_email)
-                            INSERT
-INTO events.events (start_at, end_at, program_id, location_id, created_by, updated_by)
-SELECT e.start_at,
-       e.end_at,
-       p.id,
-       l.id,
-       creator.id,
-       updater.id
+WITH events_data AS (
+    SELECT 
+        unnest($1::timestamptz[])        AS start_at,
+        unnest($2::timestamptz[])          AS end_at,
+        unnest($3::varchar[])        AS program_name,
+        unnest($4::varchar[])       AS location_name,
+        unnest($5::varchar[])    AS created_by_email,
+        unnest($6::varchar[])    AS updated_by_email
+)
+INSERT INTO events.events (
+    start_at, end_at, program_id, location_id, created_by, updated_by
+)
+SELECT 
+    e.start_at,
+    e.end_at,
+    p.id,
+    l.id,
+    creator.id,
+    updater.id
 FROM events_data e
-         JOIN program.programs p ON p.name = e.program_name
-         JOIN users.users creator ON creator.email = e.created_by_email
-         JOIN users.users updater ON updater.email = e.updated_by_email
-         JOIN location.locations l ON l.name = e.location_name
+JOIN program.programs p 
+  ON p.type = LOWER(e.program_name)::program.program_type
+JOIN users.users creator 
+  ON creator.email = e.created_by_email
+JOIN users.users updater 
+  ON updater.email = e.updated_by_email
+JOIN location.locations l 
+  ON l.name = e.location_name
 ON CONFLICT DO NOTHING
 RETURNING id
 `

--- a/cmd/seed/sqlc/generated/models.go
+++ b/cmd/seed/sqlc/generated/models.go
@@ -269,8 +269,6 @@ type ProgramProgramType string
 const (
 	ProgramProgramTypePractice ProgramProgramType = "practice"
 	ProgramProgramTypeCourse   ProgramProgramType = "course"
-	ProgramProgramTypeGame     ProgramProgramType = "game"
-	ProgramProgramTypeOthers   ProgramProgramType = "others"
 	ProgramProgramTypeOther    ProgramProgramType = "other"
 )
 
@@ -313,8 +311,6 @@ func (e ProgramProgramType) Valid() bool {
 	switch e {
 	case ProgramProgramTypePractice,
 		ProgramProgramTypeCourse,
-		ProgramProgramTypeGame,
-		ProgramProgramTypeOthers,
 		ProgramProgramTypeOther:
 		return true
 	}
@@ -325,8 +321,6 @@ func AllProgramProgramTypeValues() []ProgramProgramType {
 	return []ProgramProgramType{
 		ProgramProgramTypePractice,
 		ProgramProgramTypeCourse,
-		ProgramProgramTypeGame,
-		ProgramProgramTypeOthers,
 		ProgramProgramTypeOther,
 	}
 }

--- a/cmd/seed/sqlc/generated/program.sql.go
+++ b/cmd/seed/sqlc/generated/program.sql.go
@@ -36,72 +36,16 @@ func (q *Queries) GetProgramByType(ctx context.Context, type_ ProgramProgramType
 }
 
 const insertBuiltInPrograms = `-- name: InsertBuiltInPrograms :exec
-
 INSERT INTO program.programs (id, name, type, description)
 VALUES
-    (gen_random_uuid(), 'Practice', 'practice', 'Default program for practices'),
-    (gen_random_uuid(), 'Course', 'course', 'Default program for courses'),
-    (gen_random_uuid(), 'Other', 'other', 'Default program for other events')
-ON CONFLICT (type) DO NOTHING
+    (gen_random_uuid(), 'Practice', 'practice'::program.program_type, 'Default program for practices'),
+    (gen_random_uuid(), 'Course', 'course'::program.program_type, 'Default program for courses'),
+    (gen_random_uuid(), 'Other', 'other'::program.program_type, 'Default program for other events')
+ON CONFLICT (type) DO UPDATE
+SET name = EXCLUDED.name,
+    description = EXCLUDED.description
 `
 
-// -- name: InsertPractices :many
-// WITH prepared_data as (SELECT unnest(@name_array::text[])                   as name,
-//
-//	unnest(@description_array::text[])            as description,
-//	unnest(@level_array::program.program_level[]) as level,
-//	unnest(@is_pay_per_event_array::boolean[])    AS pay_per_event)
-//
-// INSERT
-// INTO program.programs (name, description, type, level, pay_per_event)
-// SELECT name,
-//
-//	description,
-//	'practice',
-//	level,
-//	pay_per_event
-//
-// FROM prepared_data
-// RETURNING id;
-// -- name: InsertCourses :exec
-// WITH prepared_data as (SELECT unnest(@name_array::text[])                   as name,
-//
-//	unnest(@description_array::text[])            as description,
-//	unnest(@level_array::program.program_level[]) as level,
-//	unnest(@is_pay_per_event_array::boolean[])    AS pay_per_event)
-//
-// INSERT
-// INTO program.programs (name, description, type, level, pay_per_event)
-// SELECT name,
-//
-//	description,
-//	'course',
-//	level,
-//	pay_per_event
-//
-// FROM prepared_data;
-// -- name: InsertProgramFees :exec
-// WITH prepared_data AS (SELECT unnest(@program_name_array::varchar[])            AS program_name,
-//
-//	unnest(@membership_name_array::varchar[])         AS membership_name,
-//	unnest(@stripe_program_price_id_array::varchar[]) AS stripe_program_price_id)
-//
-// INSERT
-// INTO program.fees (program_id, membership_id, stripe_price_id)
-// SELECT p.id,
-//
-//	CASE
-//	    WHEN m.id IS NULL THEN NULL::uuid
-//	    ELSE m.id
-//	    END,
-//	stripe_program_price_id
-//
-// FROM prepared_data
-//
-//	JOIN program.programs p ON p.name = program_name
-//	LEFT JOIN membership.memberships m ON m.name = membership_name
-//
-// WHERE stripe_program_price_id <> ”;
 func (q *Queries) InsertBuiltInPrograms(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, insertBuiltInPrograms)
 	return err

--- a/cmd/seed/sqlc/queries/program.sql
+++ b/cmd/seed/sqlc/queries/program.sql
@@ -1,56 +1,12 @@
--- -- name: InsertPractices :many
--- WITH prepared_data as (SELECT unnest(@name_array::text[])                   as name,
---                               unnest(@description_array::text[])            as description,
---                               unnest(@level_array::program.program_level[]) as level,
---                               unnest(@is_pay_per_event_array::boolean[])    AS pay_per_event)
--- INSERT
--- INTO program.programs (name, description, type, level, pay_per_event)
--- SELECT name,
---        description,
---        'practice',
---        level,
---        pay_per_event
--- FROM prepared_data
--- RETURNING id;
-
--- -- name: InsertCourses :exec
--- WITH prepared_data as (SELECT unnest(@name_array::text[])                   as name,
---                               unnest(@description_array::text[])            as description,
---                               unnest(@level_array::program.program_level[]) as level,
---                               unnest(@is_pay_per_event_array::boolean[])    AS pay_per_event)
--- INSERT
--- INTO program.programs (name, description, type, level, pay_per_event)
--- SELECT name,
---        description,
---        'course',
---        level,
---        pay_per_event
--- FROM prepared_data;
--- -- name: InsertProgramFees :exec
--- WITH prepared_data AS (SELECT unnest(@program_name_array::varchar[])            AS program_name,
---                               unnest(@membership_name_array::varchar[])         AS membership_name,
---                               unnest(@stripe_program_price_id_array::varchar[]) AS stripe_program_price_id)
--- INSERT
--- INTO program.fees (program_id, membership_id, stripe_price_id)
--- SELECT p.id,
---        CASE
---            WHEN m.id IS NULL THEN NULL::uuid
---            ELSE m.id
---            END,
---        stripe_program_price_id
--- FROM prepared_data
---          JOIN program.programs p ON p.name = program_name
---          LEFT JOIN membership.memberships m ON m.name = membership_name
--- WHERE stripe_program_price_id <> '';
--- name: InsertBuiltInPrograms :exec
 -- name: InsertBuiltInPrograms :exec
 INSERT INTO program.programs (id, name, type, description)
 VALUES
-    (gen_random_uuid(), 'Practice', 'practice', 'Default program for practices'),
-    (gen_random_uuid(), 'Course', 'course', 'Default program for courses'),
-    (gen_random_uuid(), 'Other', 'other', 'Default program for other events')
-ON CONFLICT (type) DO NOTHING;
-
+    (gen_random_uuid(), 'Practice', 'practice'::program.program_type, 'Default program for practices'),
+    (gen_random_uuid(), 'Course', 'course'::program.program_type, 'Default program for courses'),
+    (gen_random_uuid(), 'Other', 'other'::program.program_type, 'Default program for other events')
+ON CONFLICT (type) DO UPDATE
+SET name = EXCLUDED.name,
+    description = EXCLUDED.description;
 
 -- name: InsertProgramFees :exec
 WITH prepared_data AS (

--- a/db/migrations/20241220205709_create_programs_table.sql
+++ b/db/migrations/20241220205709_create_programs_table.sql
@@ -4,7 +4,7 @@
 CREATE schema if not exists program;
 
 CREATE TYPE program.program_level AS ENUM ('beginner', 'intermediate', 'advanced', 'all');
-CREATE TYPE program.program_type AS ENUM ('practice', 'course', 'game','others');
+CREATE TYPE program.program_type AS ENUM ('practice', 'course','other');
 
 CREATE TABLE IF NOT EXISTS program.programs
 (

--- a/db/migrations/20250507011907_insert_default_programs.sql
+++ b/db/migrations/20250507011907_insert_default_programs.sql
@@ -8,7 +8,7 @@ ADD CONSTRAINT unique_program_type UNIQUE (type);
 -- Safely insert defaults with conflict resolution on type
 INSERT INTO program.programs (id, name, type, description)
 VALUES
-    (gen_random_uuid(), 'Game', 'game', 'Default program for games'),
+   -- (gen_random_uuid(), 'Game', 'game', 'Default program for games'),
     (gen_random_uuid(), 'Practice', 'practice', 'Default program for practices'),
     (gen_random_uuid(), 'Course', 'course', 'Default program for courses'),
     (gen_random_uuid(), 'Other', 'other', 'Default program for other events')

--- a/internal/domains/game/persistence/sqlc/game_queries.sql
+++ b/internal/domains/game/persistence/sqlc/game_queries.sql
@@ -1,4 +1,13 @@
+-- The following SQL functions provide full CRUD support for the game.games table.
+-- This structure replaces the older approach of inserting game data via a WITH clause
+-- that unwrapped parallel arrays (e.g., unnesting start_times, team_names, etc.).
+-- 
+-- - The new design promotes single-row transactional inserts, which are safer and easier to debug.
+-- - Complex batch insertion with unnested arrays was moved into Go, giving more control over data preparation.
+-- - This also simplifies SQL and avoids silent failures during multi-row joins.
+
 -- name: CreateGame :exec
+-- Inserts a single game into the game.games table using direct parameters.
 INSERT INTO game.games (
   id, home_team_id, away_team_id, home_score, away_score, start_time,
   end_time, location_id, status
@@ -7,6 +16,7 @@ INSERT INTO game.games (
 );
 
 -- name: GetGameById :one
+-- Retrieves a specific game along with team names and location name.
 SELECT 
     g.id,
     g.home_team_id,
@@ -29,6 +39,7 @@ JOIN location.locations loc ON g.location_id = loc.id
 WHERE g.id = $1;
 
 -- name: GetGames :many
+-- Retrieves all games, with team and location names.
 SELECT 
     g.id,
     g.home_team_id,
@@ -51,6 +62,7 @@ JOIN location.locations loc ON g.location_id = loc.id
 ORDER BY g.start_time DESC;
 
 -- name: UpdateGame :execrows
+-- Updates an existing game's scores, times, location, and status.
 UPDATE game.games
 SET home_score = $2,
     away_score = $3,
@@ -62,5 +74,6 @@ SET home_score = $2,
 WHERE id = $1;
 
 -- name: DeleteGame :execrows
+-- Deletes a game by ID.
 DELETE FROM game.games
 WHERE id = $1;


### PR DESCRIPTION

# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
-  Removed 'game' and 'others' to fix sqlc enum generation issues
- Updated migration files to ensure program_type ENUM only includes the valid values: 'practice', 'course', and 'other'
- Regenerated models.go so that it only includes valid ProgramProgramType constants

---

# 🧠 Reason for Changes

Our models.go was generating invalid enum values (others, game) due to outdated ENUM definitions in the database. This caused mismatches in code and broke consistency across the seed process and backend logic. Fixing the ENUM values ensures cleaner code generation and prevents future migration or runtime errors.

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X ] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/5Shf2v7V/131-fix-modelgo-to-not-have-other-and-others

---

# 🗒️ Notes for Reviewer (Optional)


