### PR TITLE
[Refactor] Changed programs to have multiple program names with the same type

### DIFF
--- a/cmd/seed/sqlc/generated/models.go
+++ b/cmd/seed/sqlc/generated/models.go
@@ -348,12 +348,13 @@ type AthleticCoachStat struct {
 }
 
 type AthleticTeam struct {
-	ID        uuid.UUID     `json:"id"`
-	Name      string        `json:"name"`
-	Capacity  int32         `json:"capacity"`
-	CreatedAt time.Time     `json:"created_at"`
-	UpdatedAt time.Time     `json:"updated_at"`
-	CoachID   uuid.NullUUID `json:"coach_id"`
+	ID        uuid.UUID      `json:"id"`
+	Name      string         `json:"name"`
+	Capacity  int32          `json:"capacity"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	CoachID   uuid.NullUUID  `json:"coach_id"`
+	LogoUrl   sql.NullString `json:"logo_url"`
 }
 
 type AuditOutbox struct {

--- a/cmd/seed/sqlc/generated/program.sql.go
+++ b/cmd/seed/sqlc/generated/program.sql.go
@@ -41,8 +41,8 @@ VALUES
     (gen_random_uuid(), 'Practice', 'practice'::program.program_type, 'Default program for practices'),
     (gen_random_uuid(), 'Course', 'course'::program.program_type, 'Default program for courses'),
     (gen_random_uuid(), 'Other', 'other'::program.program_type, 'Default program for other events')
-ON CONFLICT (type) DO UPDATE
-SET name = EXCLUDED.name,
+ON CONFLICT (name) DO UPDATE
+SET type = EXCLUDED.type,
     description = EXCLUDED.description
 `
 

--- a/cmd/seed/sqlc/queries/program.sql
+++ b/cmd/seed/sqlc/queries/program.sql
@@ -4,9 +4,10 @@ VALUES
     (gen_random_uuid(), 'Practice', 'practice'::program.program_type, 'Default program for practices'),
     (gen_random_uuid(), 'Course', 'course'::program.program_type, 'Default program for courses'),
     (gen_random_uuid(), 'Other', 'other'::program.program_type, 'Default program for other events')
-ON CONFLICT (type) DO UPDATE
-SET name = EXCLUDED.name,
+ON CONFLICT (name) DO UPDATE
+SET type = EXCLUDED.type,
     description = EXCLUDED.description;
+
 
 -- name: InsertProgramFees :exec
 WITH prepared_data AS (

--- a/db/migrations/20250507011907_insert_default_programs.sql
+++ b/db/migrations/20250507011907_insert_default_programs.sql
@@ -1,18 +1,13 @@
 -- +goose Up
 -- +goose StatementBegin
 
--- Add a unique constraint so ON CONFLICT (type) works
-ALTER TABLE program.programs
-ADD CONSTRAINT unique_program_type UNIQUE (type);
-
--- Safely insert defaults with conflict resolution on type
+-- Insert default programs. No uniqueness enforced on `type`.
 INSERT INTO program.programs (id, name, type, description)
 VALUES
-   -- (gen_random_uuid(), 'Game', 'game', 'Default program for games'),
     (gen_random_uuid(), 'Practice', 'practice', 'Default program for practices'),
     (gen_random_uuid(), 'Course', 'course', 'Default program for courses'),
     (gen_random_uuid(), 'Other', 'other', 'Default program for other events')
-ON CONFLICT (type) DO NOTHING;
+ON CONFLICT (name) DO NOTHING;  -- Optional: avoid dup name conflict
 
 -- +goose StatementEnd
 
@@ -21,10 +16,6 @@ ON CONFLICT (type) DO NOTHING;
 
 -- Delete the inserted default rows
 DELETE FROM program.programs
-WHERE type IN ('game', 'practice', 'course', 'other');
-
--- Drop the unique constraint
-ALTER TABLE program.programs
-DROP CONSTRAINT IF EXISTS unique_program_type;
+WHERE name IN ('Practice', 'Course', 'Other');
 
 -- +goose StatementEnd

--- a/db/migrations/20250507204245_remove_game_and_add_games_table.sql
+++ b/db/migrations/20250507204245_remove_game_and_add_games_table.sql
@@ -37,9 +37,8 @@ BEGIN
 END
 $$;
 
--- Step 5: Recreate the unique constraint
 ALTER TABLE program.programs
-ADD CONSTRAINT unique_program_type UNIQUE (type);
+ADD CONSTRAINT unique_program_name UNIQUE (name);
 
 -- Step 6: Create game schema + games table
 CREATE SCHEMA IF NOT EXISTS game;

--- a/internal/domains/enrollment/persistence/sqlc/tests/customer_enrollment_sqlc_test.go
+++ b/internal/domains/enrollment/persistence/sqlc/tests/customer_enrollment_sqlc_test.go
@@ -32,7 +32,7 @@ func TestEnrollCustomerInEvent(t *testing.T) {
 	_, err := db.ExecContext(context.Background(), `
 	INSERT INTO program.programs (id, name, type, level, description)
 	VALUES (gen_random_uuid(), 'Course', 'course', 'all', 'Default test program')
-	ON CONFLICT (type) DO NOTHING
+	ON CONFLICT (name) DO NOTHING
 `)
 require.NoError(t, err)
 	// Create a user to be the creator of the event
@@ -130,7 +130,7 @@ func TestEnrollCustomerInProgramEvents(t *testing.T) {
 	_, err := db.ExecContext(context.Background(), `
 	INSERT INTO program.programs (id, name, type, level, description)
 	VALUES (gen_random_uuid(), 'Course', 'course', 'all', 'Default test program')
-	ON CONFLICT (type) DO NOTHING
+	ON CONFLICT (name) DO NOTHING
 	`)
 	require.NoError(t, err)
 


### PR DESCRIPTION

# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Modified the programs table to have multiple programs with the same type
- 
- 

---

# 🧠 Reason for Changes

We want to be able to have different practice programs course programs and other programs stored in the DB.

So when a user creates an event itll be based on that specific program name

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X ] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/L9FgvdOU/136-refactor-programs-to-have-multiple-programs-with-same-type
