### PR TITLE
[Refactor] Added total count to get /customers for proper front end pagination

### DIFF
--- a/internal/domains/user/persistence/repository/customer_repository.go
+++ b/internal/domains/user/persistence/repository/customer_repository.go
@@ -294,3 +294,24 @@ func (r *CustomerRepository) ListAthletes(ctx context.Context, limit, offset int
 
 	return athletes, nil
 }
+func (r *CustomerRepository) CountCustomers(ctx context.Context, parentID uuid.UUID, search string) (int64, *errLib.CommonError) {
+	searchArg := sql.NullString{Valid: false}
+	if search != "" {
+		searchArg = sql.NullString{String: search, Valid: true}
+	}
+
+	parentArg := uuid.NullUUID{Valid: false}
+	if parentID != uuid.Nil {
+		parentArg = uuid.NullUUID{UUID: parentID, Valid: true}
+	}
+
+	count, err := r.Queries.CountCustomers(ctx, db.CountCustomersParams{
+		ParentID: parentArg,
+		Search:   searchArg,
+	})
+	if err != nil {
+		return 0, errLib.New("Failed to count customers: "+err.Error(), http.StatusInternalServerError)
+	}
+
+	return count, nil
+}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added customerCount which counts the total customers in the db
- This allows the frontend to implement proper paginated buttons and pages for our tables
- now the user will see what page they are on and can navigate between the pages easier
- 

---

# 🧠 Reason for Changes

Before, on the admin panel we would only display 20 customers because the limit was set to 20 and there was no way to go through more customers.

so now we have the ability to only call 10 customers per page at a time and the user can navigate through the pages easier.

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/DYY8WX85/188-display-more-customers-properly-only-displays-20

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

