### PR TITLE
[Feature] upcoming bookings

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -7,10 +7,10 @@ import (
 	barberServicesHandler "api/internal/domains/haircut/haircut_service"
 	haircut "api/internal/domains/haircut/portfolio"
 
-	enrollmentHandler "api/internal/domains/enrollment/handler"
-
-	courtHandler "api/internal/domains/court/handler"
+	bookingsHandler "api/internal/domains/booking/handler"
+	courtHandler "api/internal/domains/court/handler" 
 	discountHandler "api/internal/domains/discount/handler"
+	enrollmentHandler "api/internal/domains/enrollment/handler"
 	eventHandler "api/internal/domains/event/handler"
 	"api/internal/domains/game"
 	"api/internal/domains/identity/handler/authentication"
@@ -56,6 +56,7 @@ func RegisterRoutes(router *chi.Mux, container *di.Container) {
 		"/discounts":  RegisterDiscountRoutes,
 		"/courts":     RegisterCourtsRoutes,
 		"/practices":  RegisterPracticesRoutes,
+		"/bookings":   RegisterBookingsRoutes,
 
 		// Users & Staff routes
 		"/users":     RegisterUserRoutes,
@@ -412,5 +413,12 @@ func RegisterSecureCustomerRoutes(container *di.Container) func(chi.Router) {
 	h := userHandler.NewCustomersHandler(container)
 	return func(r chi.Router) {
 		r.With(middlewares.JWTAuthMiddleware(true)).Get("/memberships", h.GetUserMembershipHistory)
+	}
+}
+
+func RegisterBookingsRoutes(container *di.Container) func(chi.Router) {
+	h := bookingsHandler.NewHandler(container)
+	return func(r chi.Router) {
+		r.With(middlewares.JWTAuthMiddleware(true)).Get("/upcoming", h.GetMyUpcomingBookings)
 	}
 }

--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -427,7 +427,7 @@ func RegisterAIRoutes(_ *di.Container) func(chi.Router) {
 		r.With(middlewares.RateLimitMiddleware(0.2, 1, time.Minute)).Post("/chat", h.ProxyMessage)
 	}
 }
-
+// RegisterBookingsRoutes registers the bookings routes.
 func RegisterBookingsRoutes(container *di.Container) func(chi.Router) {
 	h := bookingsHandler.NewHandler(container)
 	return func(r chi.Router) {

--- a/internal/domains/booking/handler/booking_handler.go
+++ b/internal/domains/booking/handler/booking_handler.go
@@ -1,0 +1,82 @@
+package booking
+
+import (
+	"api/internal/di"
+	hairDto "api/internal/domains/haircut/event/dto"
+	hairRepo "api/internal/domains/haircut/event/persistence"
+	playgroundDto "api/internal/domains/playground/dto/session"
+	playgroundService "api/internal/domains/playground/services"
+	responseHandlers "api/internal/libs/responses"
+	contextUtils "api/utils/context"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Handler aggregates bookings from multiple domains.
+type Handler struct {
+	HaircutRepo       *hairRepo.Repository
+	PlaygroundService *playgroundService.Service
+}
+
+// NewHandler creates a new Handler instance.
+func NewHandler(container *di.Container) *Handler {
+	return &Handler{
+		HaircutRepo:       hairRepo.NewEventsRepository(container),
+		PlaygroundService: playgroundService.NewService(container),
+	}
+}
+
+// UpcomingBookingsResponse represents combined upcoming bookings.
+type UpcomingBookingsResponse struct {
+	Haircuts   []hairDto.EventResponseDto  `json:"haircuts"`
+	Playground []playgroundDto.ResponseDto `json:"playground"`
+}
+
+// GetMyUpcomingBookings returns upcoming haircut and playground bookings for the logged-in customer.
+// @Tags bookings
+// @Produce json
+// @Security Bearer
+// @Success 200 {object} booking.UpcomingBookingsResponse "Upcoming bookings"
+// @Failure 401 {object} map[string]interface{} "Unauthorized"
+// @Failure 500 {object} map[string]interface{} "Internal Server Error"
+// @Router /bookings/upcoming [get]
+func (h *Handler) GetMyUpcomingBookings(w http.ResponseWriter, r *http.Request) {
+	customerID, err := contextUtils.GetUserID(r.Context())
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	events, err := h.HaircutRepo.GetEvents(r.Context(), uuid.Nil, customerID, time.Time{}, time.Time{})
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+	now := time.Now()
+	var haircutBookings []hairDto.EventResponseDto
+	for _, e := range events {
+		if e.BeginDateTime.After(now) {
+			haircutBookings = append(haircutBookings, hairDto.NewEventResponse(e))
+		}
+	}
+
+	sessions, err := h.PlaygroundService.GetSessions(r.Context())
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+	var playgroundBookings []playgroundDto.ResponseDto
+	for _, s := range sessions {
+		if s.CustomerID == customerID && s.StartTime.After(now) {
+			playgroundBookings = append(playgroundBookings, playgroundDto.NewResponse(s))
+		}
+	}
+
+	resp := UpcomingBookingsResponse{
+		Haircuts:   haircutBookings,
+		Playground: playgroundBookings,
+	}
+	responseHandlers.RespondWithSuccess(w, resp, http.StatusOK)
+}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
-  Added a new endpoint /bookings/upcoming
- this displays a user's upcoming haircut and playground bookings
- Only had to add a handler file under internal/domains/booking/handler/booking_handler.go
- 
- 

---

# 🧠 Reason for Changes

Users can now stay up to date with their upcoming bookings and have access to see the details of said booking

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/Jq0qHctJ/244-add-upcoming-bookings

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

