### PR TITLE
[Feature] chatbot rate limiting and proper dto request struct

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -423,6 +423,6 @@ func RegisterSecureCustomerRoutes(container *di.Container) func(chi.Router) {
 func RegisterAIRoutes(_ *di.Container) func(chi.Router) {
 	h := aiHandler.NewHandler()
 	return func(r chi.Router) {
-		r.With(middlewares.RateLimitMiddleware(1.0, 5, time.Minute)).Post("/chat", h.ProxyMessage)
+		r.With(middlewares.RateLimitMiddleware(1.0, 4, time.Minute)).Post("/chat", h.ProxyMessage)
 	}
 }

--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -423,6 +423,6 @@ func RegisterSecureCustomerRoutes(container *di.Container) func(chi.Router) {
 func RegisterAIRoutes(_ *di.Container) func(chi.Router) {
 	h := aiHandler.NewHandler()
 	return func(r chi.Router) {
-		r.With(middlewares.RateLimitMiddleware(0.2, 1, time.Minute)).Post("/chat", h.ProxyMessage)
+		r.With(middlewares.RateLimitMiddleware(1.0, 3, time.Minute)).Post("/chat", h.ProxyMessage)
 	}
 }

--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -423,6 +423,6 @@ func RegisterSecureCustomerRoutes(container *di.Container) func(chi.Router) {
 func RegisterAIRoutes(_ *di.Container) func(chi.Router) {
 	h := aiHandler.NewHandler()
 	return func(r chi.Router) {
-		r.With(middlewares.RateLimitMiddleware(1.0, 3, time.Minute)).Post("/chat", h.ProxyMessage)
+		r.With(middlewares.RateLimitMiddleware(1.0, 5, time.Minute)).Post("/chat", h.ProxyMessage)
 	}
 }

--- a/internal/domains/ai/dto/ai.go
+++ b/internal/domains/ai/dto/ai.go
@@ -1,7 +1,7 @@
 package dto
 
 type ChatRequest struct {
-	Message     string     `json:"message"`
+	Query       string     `json:"query"`
 	Context     string     `json:"context"`
 	ChatHistory [][]string `json:"chat_history"`
 }

--- a/internal/domains/ai/handler/handler.go
+++ b/internal/domains/ai/handler/handler.go
@@ -37,17 +37,17 @@ func (h *Handler) ProxyMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req.Message = strings.TrimSpace(req.Message)
+	req.Query = strings.TrimSpace(req.Query)
 	req.Context = strings.TrimSpace(req.Context)
-	req.Message = html.EscapeString(req.Message)
-	if req.Message == "" {
-		responses.RespondWithError(w, errLib.New("message is required", http.StatusBadRequest))
+	req.Query = html.EscapeString(req.Query)
+	if req.Query == "" {
+		responses.RespondWithError(w, errLib.New("query is required", http.StatusBadRequest))
 		return
 	}
 
-	log.Printf("AI chat request: %s", req.Message)
+	log.Printf("AI chat request: %s", req.Query)
 
-	reply, err := h.svc.Chat(req.Message, req.Context, req.ChatHistory)
+	reply, err := h.svc.Chat(req.Query, req.Context, req.ChatHistory)
 	if err != nil {
 		responses.RespondWithError(w, err)
 		return

--- a/internal/domains/ai/service/service.go
+++ b/internal/domains/ai/service/service.go
@@ -5,6 +5,8 @@ import (
 	errLib "api/internal/libs/errors"
 	"bytes"
 	"encoding/json"
+	"io"
+	"log"
 	"net/http"
 	"time"
 )
@@ -16,49 +18,61 @@ type Service struct {
 
 func NewService() *Service {
 	return &Service{
-		Client:  &http.Client{Timeout: 15 * time.Second},
+		Client:  &http.Client{Timeout: 30 * time.Second},
 		BaseURL: config.Env.ChatBotServiceUrl,
 	}
 }
 
 func (s *Service) Chat(message, context string, chatHistory [][]string) (string, *errLib.CommonError) {
 	if s.BaseURL == "" {
+		log.Println("[Chat Debug] ChatBotServiceUrl is empty")
 		return "", errLib.New("chatbot service URL not configured", http.StatusInternalServerError)
 	}
+
+	log.Printf("[Chat Debug] Using chatbot URL: %s", s.BaseURL)
 
 	reqBody := map[string]interface{}{
 		"query":        message,
 		"chat_history": chatHistory,
 	}
-
 	buf, err := json.Marshal(reqBody)
 	if err != nil {
+		log.Printf("[Chat Debug] Failed to marshal request body: %v", err)
 		return "", errLib.New("failed to marshal request", http.StatusInternalServerError)
 	}
 
+	log.Printf("[Chat Debug] Request Body: %s", string(buf))
+
 	httpReq, err := http.NewRequest(http.MethodPost, s.BaseURL, bytes.NewBuffer(buf))
 	if err != nil {
+		log.Printf("[Chat Debug] Failed to create HTTP request: %v", err)
 		return "", errLib.New("failed to create request", http.StatusInternalServerError)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := s.Client.Do(httpReq)
 	if err != nil {
+		log.Printf("[Chat Debug] HTTP request failed: %v", err)
 		return "", errLib.New("failed to contact chat service", http.StatusBadGateway)
 	}
 	defer resp.Body.Close()
 
+	log.Printf("[Chat Debug] Response Status Code: %d", resp.StatusCode)
+
 	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		log.Printf("[Chat Debug] Error Response Body: %s", string(body))
 		return "", errLib.New("chat service error", http.StatusBadGateway)
 	}
 
 	var res struct {
 		Answer string `json:"answer"`
 	}
-
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		log.Printf("[Chat Debug] Failed to decode response: %v", err)
 		return "", errLib.New("invalid chat response", http.StatusInternalServerError)
 	}
 
+	log.Printf("[Chat Debug] Chatbot Answer: %s", res.Answer)
 	return res.Answer, nil
 }


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- 
- Changed the dto to have the proper dto request struct for the chatbot 
- changed the rate limiting to 5 message burst and then 1 second after that
- Added debugging to the service.go file

---

# 🧠 Reason for Changes

We were getting timed out too fast and the dto was incorrect

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/LxhfMma1/236-create-a-proxy-for-ai-chatbot-message-requests-to-be-forwaredd

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

