### PR TITLE
[fix] nullable court_id 

### DIFF
--- a/internal/domains/event/persistence/sqlc/generated/event_queries.sql.go
+++ b/internal/domains/event/persistence/sqlc/generated/event_queries.sql.go
@@ -40,7 +40,7 @@ INTO events.events (location_id,
                     is_cancelled,
                     cancellation_reason)
 SELECT location_id,
-         court_id,
+        NULLIF(court_id, '00000000-0000-0000-0000-000000000000'::uuid),
        program_id,
        NULLIF(team_id, '00000000-0000-0000-0000-000000000000'::uuid),
        start_at,

--- a/internal/domains/event/persistence/sqlc/queries/event_queries.sql
+++ b/internal/domains/event/persistence/sqlc/queries/event_queries.sql
@@ -24,7 +24,7 @@ INTO events.events (location_id,
                     is_cancelled,
                     cancellation_reason)
 SELECT location_id,
-         court_id,
+        NULLIF(court_id, '00000000-0000-0000-0000-000000000000'::uuid),
        program_id,
        NULLIF(team_id, '00000000-0000-0000-0000-000000000000'::uuid),
        start_at,


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- fixed sqlc to have court id nullable when creating an event
- 
- 

---

# 🧠 Reason for Changes

the code was forcing a court id to be present when creating an event

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
Example: `https://trello.com/c/your-task-id`

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

