### PR TITLE
[Feature} Add support for flexible joining fees in membership plans

### DIFF
--- a/db/migrations/20250911000000_add_joining_fee_to_membership_plans.sql
+++ b/db/migrations/20250911000000_add_joining_fee_to_membership_plans.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Add joining_fee column to membership_plans table
+ALTER TABLE membership.membership_plans 
+ADD COLUMN joining_fee INTEGER DEFAULT 0 NOT NULL;
+
+-- Add comment to explain the field
+COMMENT ON COLUMN membership.membership_plans.joining_fee IS 'One-time joining fee in cents (e.g., 13000 = $130.00). Applied as Stripe setup fee on first payment only.';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Remove joining_fee column
+ALTER TABLE membership.membership_plans 
+DROP COLUMN IF EXISTS joining_fee;
+
+-- +goose StatementEnd

--- a/internal/domains/membership/dto/membership_plan/responses.go
+++ b/internal/domains/membership/dto/membership_plan/responses.go
@@ -20,12 +20,15 @@ type PlanResponse struct {
 	Currency            string    `json:"currency"`
 	Interval            string    `json:"interval"`
 	Price               string    `json:"price"`
+	JoiningFee          int       `json:"joining_fee"`
+	JoiningFeeDisplay   string    `json:"joining_fee_display"`
 	CreatedAt           time.Time `json:"created_at"`
 	UpdatedAt           time.Time `json:"updated_at"`
 }
 
 func NewPlanResponse(plan values.PlanReadValues) PlanResponse {
 	displayPrice := fmt.Sprintf("$%.2f", float64(plan.UnitAmount)/100) // convert unit_amount to dollars and format as string
+	joiningFeeDisplay := fmt.Sprintf("$%.2f", float64(plan.JoiningFee)/100) // convert joining_fee to dollars and format as string
 
 	return PlanResponse{
 		MembershipID:        plan.MembershipID,
@@ -38,6 +41,8 @@ func NewPlanResponse(plan values.PlanReadValues) PlanResponse {
 		Currency:            strings.ToUpper(plan.Currency), // e.g. "USD", "CAD"
 		Interval:            plan.Interval, // e.g. "month", "year", weekly, etc.
 		Price:               displayPrice, // e.g. "$10.00" display price
+		JoiningFee:          plan.JoiningFee,
+		JoiningFeeDisplay:   joiningFeeDisplay, // e.g. "$130.00" display price
 		CreatedAt:           plan.CreatedAt,
 		UpdatedAt:           plan.UpdatedAt,
 	}

--- a/internal/domains/membership/persistence/repositories/plans.go
+++ b/internal/domains/membership/persistence/repositories/plans.go
@@ -46,6 +46,7 @@ func (r *PlansRepository) CreateMembershipPlan(c context.Context, membershipPlan
 			Valid:  membershipPlan.StripeJoiningFeesID != "",
 		},
 		StripePriceID: membershipPlan.StripePriceID,
+		JoiningFee:    int32(membershipPlan.JoiningFee),
 	}
 
 	if membershipPlan.AmtPeriods != nil {
@@ -95,6 +96,7 @@ func (r *PlansRepository) GetMembershipPlanById(ctx context.Context, id uuid.UUI
 			Name:                dbPlan.Name,
 			StripeJoiningFeesID: dbPlan.StripeJoiningFeeID.String,
 			StripePriceID:       dbPlan.StripePriceID,
+			JoiningFee:          int(dbPlan.JoiningFee),
 		},
 		CreatedAt: dbPlan.CreatedAt,
 		UpdatedAt: dbPlan.UpdatedAt,
@@ -127,6 +129,7 @@ func (r *PlansRepository) GetMembershipPlans(ctx context.Context, membershipId u
 				Name:                dbPlan.Name,
 				StripeJoiningFeesID: dbPlan.StripeJoiningFeeID.String,
 				StripePriceID:       dbPlan.StripePriceID,
+				JoiningFee:          int(dbPlan.JoiningFee),
 			},
 			CreatedAt: dbPlan.CreatedAt,
 			UpdatedAt: dbPlan.UpdatedAt,
@@ -164,6 +167,7 @@ func (r *PlansRepository) UpdateMembershipPlan(c context.Context, plan values.Pl
 			Valid:  plan.StripeJoiningFeesID != "",
 		},
 		StripePriceID: plan.StripePriceID,
+		JoiningFee:    int32(plan.JoiningFee),
 	}
 
 	if plan.AmtPeriods != nil {

--- a/internal/domains/membership/persistence/sqlc/generated/plans.sql.go
+++ b/internal/domains/membership/persistence/sqlc/generated/plans.sql.go
@@ -14,9 +14,9 @@ import (
 )
 
 const createMembershipPlan = `-- name: CreateMembershipPlan :one
-INSERT INTO membership.membership_plans (membership_id, name, stripe_joining_fee_id, stripe_price_id, amt_periods)
-VALUES ($1, $2, $3, $4, $5)
-RETURNING id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval
+INSERT INTO membership.membership_plans (membership_id, name, stripe_joining_fee_id, stripe_price_id, amt_periods, joining_fee)
+VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval, joining_fee
 `
 
 type CreateMembershipPlanParams struct {
@@ -25,6 +25,7 @@ type CreateMembershipPlanParams struct {
 	StripeJoiningFeeID sql.NullString `json:"stripe_joining_fee_id"`
 	StripePriceID      string         `json:"stripe_price_id"`
 	AmtPeriods         sql.NullInt32  `json:"amt_periods"`
+	JoiningFee         int32          `json:"joining_fee"`
 }
 
 func (q *Queries) CreateMembershipPlan(ctx context.Context, arg CreateMembershipPlanParams) (MembershipMembershipPlan, error) {
@@ -34,6 +35,7 @@ func (q *Queries) CreateMembershipPlan(ctx context.Context, arg CreateMembership
 		arg.StripeJoiningFeeID,
 		arg.StripePriceID,
 		arg.AmtPeriods,
+		arg.JoiningFee,
 	)
 	var i MembershipMembershipPlan
 	err := row.Scan(
@@ -48,6 +50,7 @@ func (q *Queries) CreateMembershipPlan(ctx context.Context, arg CreateMembership
 		&i.UnitAmount,
 		&i.Currency,
 		&i.Interval,
+		&i.JoiningFee,
 	)
 	return i, err
 }
@@ -65,7 +68,7 @@ func (q *Queries) DeleteMembershipPlan(ctx context.Context, id uuid.UUID) (int64
 }
 
 const getMembershipPlanById = `-- name: GetMembershipPlanById :one
-SELECT id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval
+SELECT id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval, joining_fee
 FROM membership.membership_plans
 WHERE id = $1
 `
@@ -85,6 +88,7 @@ func (q *Queries) GetMembershipPlanById(ctx context.Context, id uuid.UUID) (Memb
 		&i.UnitAmount,
 		&i.Currency,
 		&i.Interval,
+		&i.JoiningFee,
 	)
 	return i, err
 }
@@ -100,6 +104,7 @@ SELECT
   mp.unit_amount,
   mp.currency,
   mp.interval,
+  mp.joining_fee,
   mp.created_at,
   mp.updated_at
 FROM membership.membership_plans mp
@@ -116,6 +121,7 @@ type GetMembershipPlansRow struct {
 	UnitAmount         sql.NullInt32  `json:"unit_amount"`
 	Currency           sql.NullString `json:"currency"`
 	Interval           sql.NullString `json:"interval"`
+	JoiningFee         int32          `json:"joining_fee"`
 	CreatedAt          time.Time      `json:"created_at"`
 	UpdatedAt          time.Time      `json:"updated_at"`
 }
@@ -139,6 +145,7 @@ func (q *Queries) GetMembershipPlans(ctx context.Context, membershipID uuid.UUID
 			&i.UnitAmount,
 			&i.Currency,
 			&i.Interval,
+			&i.JoiningFee,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -162,9 +169,10 @@ SET name              = $1,
     stripe_joining_fee_id = $3,
     amt_periods       = $4,
     membership_id     = $5,
+    joining_fee       = $6,
     updated_at        = CURRENT_TIMESTAMP
-WHERE id = $6
-RETURNING id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval
+WHERE id = $7
+RETURNING id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval, joining_fee
 `
 
 type UpdateMembershipPlanParams struct {
@@ -173,6 +181,7 @@ type UpdateMembershipPlanParams struct {
 	StripeJoiningFeeID sql.NullString `json:"stripe_joining_fee_id"`
 	AmtPeriods         sql.NullInt32  `json:"amt_periods"`
 	MembershipID       uuid.UUID      `json:"membership_id"`
+	JoiningFee         int32          `json:"joining_fee"`
 	ID                 uuid.UUID      `json:"id"`
 }
 
@@ -183,6 +192,7 @@ func (q *Queries) UpdateMembershipPlan(ctx context.Context, arg UpdateMembership
 		arg.StripeJoiningFeeID,
 		arg.AmtPeriods,
 		arg.MembershipID,
+		arg.JoiningFee,
 		arg.ID,
 	)
 	var i MembershipMembershipPlan
@@ -198,6 +208,7 @@ func (q *Queries) UpdateMembershipPlan(ctx context.Context, arg UpdateMembership
 		&i.UnitAmount,
 		&i.Currency,
 		&i.Interval,
+		&i.JoiningFee,
 	)
 	return i, err
 }

--- a/internal/domains/membership/persistence/sqlc/queries/plans.sql
+++ b/internal/domains/membership/persistence/sqlc/queries/plans.sql
@@ -1,6 +1,6 @@
 -- name: CreateMembershipPlan :one
-INSERT INTO membership.membership_plans (membership_id, name, stripe_joining_fee_id, stripe_price_id, amt_periods)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO membership.membership_plans (membership_id, name, stripe_joining_fee_id, stripe_price_id, amt_periods, joining_fee)
+VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING *;
 
 -- name: GetMembershipPlanById :one
@@ -19,6 +19,7 @@ SELECT
   mp.unit_amount,
   mp.currency,
   mp.interval,
+  mp.joining_fee,
   mp.created_at,
   mp.updated_at
 FROM membership.membership_plans mp
@@ -32,8 +33,9 @@ SET name              = $1,
     stripe_joining_fee_id = $3,
     amt_periods       = $4,
     membership_id     = $5,
+    joining_fee       = $6,
     updated_at        = CURRENT_TIMESTAMP
-WHERE id = $6
+WHERE id = $7
 RETURNING *;
 
 -- name: DeleteMembershipPlan :execrows

--- a/internal/domains/membership/values/plans.go
+++ b/internal/domains/membership/values/plans.go
@@ -12,6 +12,7 @@ type PlanDetails struct {
 	AmtPeriods          *int32
 	StripeJoiningFeesID string
 	StripePriceID       string
+	JoiningFee          int
 }
 
 type PlanCreateValues struct {

--- a/internal/domains/payment/persistence/repositories/checkout.go
+++ b/internal/domains/payment/persistence/repositories/checkout.go
@@ -44,6 +44,7 @@ func (r *CheckoutRepository) GetMembershipPlanJoiningRequirement(ctx context.Con
 			ID:            requirements.ID,
 			Name:          requirements.Name,
 			StripePriceID: requirements.StripePriceID,
+			JoiningFee:    int(requirements.JoiningFee),
 			MembershipID:  requirements.MembershipID,
 			CreatedAt:     requirements.CreatedAt,
 			UpdatedAt:     requirements.UpdatedAt,

--- a/internal/domains/payment/persistence/sqlc/generated/memberships.sql.go
+++ b/internal/domains/payment/persistence/sqlc/generated/memberships.sql.go
@@ -78,7 +78,7 @@ func (q *Queries) GetMembershipPlanByStripePriceId(ctx context.Context, stripePr
 }
 
 const getMembershipPlanJoiningRequirements = `-- name: GetMembershipPlanJoiningRequirements :one
-SELECT id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval
+SELECT id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval, joining_fee
 FROM membership.membership_plans
 WHERE id = $1
 `
@@ -98,6 +98,7 @@ func (q *Queries) GetMembershipPlanJoiningRequirements(ctx context.Context, id u
 		&i.UnitAmount,
 		&i.Currency,
 		&i.Interval,
+		&i.JoiningFee,
 	)
 	return i, err
 }

--- a/internal/domains/payment/values/purchase_info.go
+++ b/internal/domains/payment/values/purchase_info.go
@@ -10,6 +10,7 @@ type MembershipPlanJoiningRequirement struct {
 	Name               string
 	StripePriceID      string
 	StripeJoiningFeeID string
+	JoiningFee         int
 	MembershipID       uuid.UUID
 	AmtPeriods         *int32
 	CreatedAt          time.Time


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- 
- Allows stripe to charge a one time payment for joining fees but does not have it set up for recurring fees annually
- 

---

# 🧠 Reason for Changes

Rise wants to charge 130 for every user that joins and then charge it again yearly

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/O0TZqjOW/331-add-annual-charges-for-certain-memberships

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

