### PR TITLE
Added updating profile pictures

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -24,6 +24,7 @@ import (
 	programHandler "api/internal/domains/program"
 	schedule "api/internal/domains/schedule/handler"
 	teamsHandler "api/internal/domains/team"
+	uploadHandler "api/internal/domains/upload/handler"
 	userHandler "api/internal/domains/user/handler"
 	"api/internal/middlewares"
 	contextUtils "api/utils/context"
@@ -66,6 +67,7 @@ func RegisterRoutes(router *chi.Mux, container *di.Container) {
 		"/customers": RegisterCustomerRoutes,
 		"/athletes":  RegisterAthleteRoutes,
 		"/staffs":    RegisterStaffRoutes,
+		"/upload":    RegisterUploadRoutes,
 
 		// Haircut routes
 		"/haircuts":         RegisterHaircutRoutes,
@@ -125,7 +127,7 @@ func RegisterAthleteRoutes(container *di.Container) func(chi.Router) {
 	return func(r chi.Router) {
 		r.Get("/", h.GetAthletes)
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin)).Patch("/{id}/stats", h.UpdateAthleteStats)
-		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin)).Patch("/{id}/profile", h.UpdateAthleteProfile)
+		r.With(middlewares.JWTAuthMiddleware(false)).Patch("/{id}/profile", h.UpdateAthleteProfile)
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin)).Put("/{athlete_id}/team/{team_id}", h.UpdateAthletesTeam)
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin)).Delete("/{athlete_id}/team", h.RemoveAthleteFromTeam)
 	}
@@ -287,6 +289,7 @@ func RegisterStaffRoutes(container *di.Container) func(chi.Router) {
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin)).Get("/logs", staffLogsHandlers.GetStaffActivityLogs)
 
 		r.With(middlewares.JWTAuthMiddleware(false)).Put("/{id}", staffHandlers.UpdateStaff)
+		r.With(middlewares.JWTAuthMiddleware(false)).Patch("/{id}/profile", staffHandlers.UpdateStaffProfile)
 		r.With(middlewares.JWTAuthMiddleware(false)).Delete("/{id}", staffHandlers.DeleteStaff)
 	}
 }
@@ -540,5 +543,13 @@ func RegisterAdminRoutes(container *di.Container) func(chi.Router) {
 		r.Post("/customers/{id}/credits/deduct", creditHandler.DeductCustomerCredits)
 		r.Get("/events/{id}/credit-transactions", creditHandler.GetEventCreditTransactions)
 		r.Put("/events/{id}/credit-cost", creditHandler.UpdateEventCreditCost)
+	}
+}
+
+func RegisterUploadRoutes(container *di.Container) func(chi.Router) {
+	uploadHandlers := uploadHandler.NewUploadHandler(container)
+
+	return func(r chi.Router) {
+		r.With(middlewares.JWTAuthMiddleware(true)).Post("/image", uploadHandlers.UploadImage)
 	}
 }

--- a/internal/domains/upload/handler/upload_handler.go
+++ b/internal/domains/upload/handler/upload_handler.go
@@ -1,0 +1,113 @@
+package upload
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"api/internal/di"
+	errLib "api/internal/libs/errors"
+	responseHandlers "api/internal/libs/responses"
+	"api/internal/services/gcp"
+	contextUtils "api/utils/context"
+
+	"github.com/google/uuid"
+)
+
+type UploadHandler struct{}
+
+func NewUploadHandler(container *di.Container) *UploadHandler {
+	return &UploadHandler{}
+}
+
+// UploadImage handles image uploads to cloud storage
+// @Summary Upload image to cloud storage
+// @Description Accepts an image file and uploads it to Google Cloud Storage, returning the public URL
+// @Tags upload
+// @Accept multipart/form-data
+// @Produce json
+// @Param image formData file true "Image file to upload (jpg, jpeg, png, gif, webp)"
+// @Param folder query string false "Folder name in storage bucket" default("images")
+// @Security Bearer
+// @Success 200 {object} map[string]interface{} "Image uploaded successfully"
+// @Failure 400 {object} map[string]interface{} "Bad Request: Invalid file or file type"
+// @Failure 401 {object} map[string]interface{} "Unauthorized"
+// @Failure 413 {object} map[string]interface{} "Payload Too Large: File size exceeds limit"
+// @Failure 500 {object} map[string]interface{} "Internal Server Error"
+// @Router /upload/image [post]
+func (h *UploadHandler) UploadImage(w http.ResponseWriter, r *http.Request) {
+	// Limit file size to 10MB
+	r.ParseMultipartForm(10 << 20)
+
+	// Get the file from the request
+	file, header, err := r.FormFile("image")
+	if err != nil {
+		responseHandlers.RespondWithError(w, errLib.New("No image file provided", http.StatusBadRequest))
+		return
+	}
+	defer file.Close()
+
+	// Validate file size (10MB limit)
+	if header.Size > 10<<20 {
+		responseHandlers.RespondWithError(w, errLib.New("File size exceeds 10MB limit", http.StatusRequestEntityTooLarge))
+		return
+	}
+
+	// Validate file type
+	if !isValidImageType(header.Filename) {
+		responseHandlers.RespondWithError(w, errLib.New("Invalid file type. Only jpg, jpeg, png, gif, and webp are allowed", http.StatusBadRequest))
+		return
+	}
+
+	// Get folder from query params (default to "images")
+	folder := r.URL.Query().Get("folder")
+	if folder == "" {
+		folder = "images"
+	}
+
+	// Get user ID for organized storage
+	userID, userErr := contextUtils.GetUserID(r.Context())
+	var userPrefix string
+	if userErr == nil {
+		userPrefix = userID.String()
+	} else {
+		userPrefix = "anonymous"
+	}
+
+	// Generate unique filename
+	timestamp := time.Now().Unix()
+	fileExt := strings.ToLower(filepath.Ext(header.Filename))
+	uniqueID := uuid.New().String()
+	fileName := fmt.Sprintf("%s/%s/%d_%s%s", folder, userPrefix, timestamp, uniqueID, fileExt)
+
+	// Upload to GCP Storage
+	publicURL, uploadErr := gcp.UploadImageToGCP(file, fileName)
+	if uploadErr != nil {
+		responseHandlers.RespondWithError(w, uploadErr)
+		return
+	}
+
+	response := map[string]interface{}{
+		"message":    "Image uploaded successfully",
+		"url":        publicURL,
+		"filename":   fileName,
+		"size_bytes": header.Size,
+	}
+
+	responseHandlers.RespondWithSuccess(w, response, http.StatusOK)
+}
+
+// isValidImageType checks if the file has a valid image extension
+func isValidImageType(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	validExtensions := []string{".jpg", ".jpeg", ".png", ".gif", ".webp"}
+	
+	for _, validExt := range validExtensions {
+		if ext == validExt {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/domains/user/dto/staff/profile_requests.go
+++ b/internal/domains/user/dto/staff/profile_requests.go
@@ -1,0 +1,25 @@
+package staff
+
+import (
+	values "api/internal/domains/user/values"
+	errLib "api/internal/libs/errors"
+	"api/internal/libs/validators"
+)
+
+// StaffProfileUpdateRequestDto represents the request dto for updating staff profile information.
+type StaffProfileUpdateRequestDto struct {
+	PhotoURL *string `json:"photo_url,omitempty"`
+}
+
+// ToUpdateValue converts the staff profile update request DTO to domain values.
+func (dto StaffProfileUpdateRequestDto) ToUpdateValue(idStr string) (values.UpdateStaffProfileValues, *errLib.CommonError) {
+	id, err := validators.ParseUUID(idStr)
+	if err != nil {
+		return values.UpdateStaffProfileValues{}, err
+	}
+
+	return values.UpdateStaffProfileValues{
+		ID:       id,
+		PhotoURL: dto.PhotoURL,
+	}, nil
+}

--- a/internal/domains/user/persistence/repository/staff_repository.go
+++ b/internal/domains/user/persistence/repository/staff_repository.go
@@ -136,7 +136,27 @@ func (r *StaffRepository) Update(ctx context.Context, staffFields values.UpdateS
 	}
 
 	return nil
+}
 
+func (r *StaffRepository) UpdateStaffProfile(ctx context.Context, staffProfile values.UpdateStaffProfileValues) *errLib.CommonError {
+	var photoURL sql.NullString
+	if staffProfile.PhotoURL != nil {
+		photoURL = sql.NullString{String: *staffProfile.PhotoURL, Valid: true}
+	}
+
+	dbStaffProfileParams := db.UpdateStaffProfileParams{
+		ID:       staffProfile.ID,
+		PhotoUrl: photoURL,
+	}
+
+	if affectedRows, err := r.Queries.UpdateStaffProfile(ctx, dbStaffProfileParams); err != nil {
+		log.Printf("Failed to update staff profile %+v. Error: %v", staffProfile.ID, err.Error())
+		return errLib.New("Internal server error", http.StatusInternalServerError)
+	} else if affectedRows == 0 {
+		return errLib.New("Staff not found", http.StatusNotFound)
+	}
+
+	return nil
 }
 
 func (r *StaffRepository) Delete(c context.Context, id uuid.UUID) *errLib.CommonError {

--- a/internal/domains/user/persistence/sqlc/generated/models.go
+++ b/internal/domains/user/persistence/sqlc/generated/models.go
@@ -590,6 +590,8 @@ type MembershipMembershipPlan struct {
 	UnitAmount         sql.NullInt32  `json:"unit_amount"`
 	Currency           sql.NullString `json:"currency"`
 	Interval           sql.NullString `json:"interval"`
+	// One-time joining fee in cents (e.g., 13000 = $130.00). Applied as Stripe setup fee on first payment only.
+	JoiningFee int32 `json:"joining_fee"`
 }
 
 type PlaygroundSession struct {

--- a/internal/domains/user/persistence/sqlc/generated/staff.sql.go
+++ b/internal/domains/user/persistence/sqlc/generated/staff.sql.go
@@ -199,3 +199,23 @@ func (q *Queries) UpdateStaff(ctx context.Context, arg UpdateStaffParams) (int64
 	}
 	return result.RowsAffected()
 }
+
+const updateStaffProfile = `-- name: UpdateStaffProfile :execrows
+UPDATE staff.staff
+SET photo_url = $2,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = $1
+`
+
+type UpdateStaffProfileParams struct {
+	ID       uuid.UUID      `json:"id"`
+	PhotoUrl sql.NullString `json:"photo_url"`
+}
+
+func (q *Queries) UpdateStaffProfile(ctx context.Context, arg UpdateStaffProfileParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateStaffProfile, arg.ID, arg.PhotoUrl)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/internal/domains/user/persistence/sqlc/queries/staff.sql
+++ b/internal/domains/user/persistence/sqlc/queries/staff.sql
@@ -20,6 +20,12 @@ UPDATE staff.staff s
         updated_at = CURRENT_TIMESTAMP
 WHERE s.id = $3;
 
+-- name: UpdateStaffProfile :execrows
+UPDATE staff.staff
+SET photo_url = $2,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = $1;
+
 -- name: DeleteStaff :execrows
 DELETE
 FROM staff.staff

--- a/internal/domains/user/values/staff.go
+++ b/internal/domains/user/values/staff.go
@@ -40,3 +40,8 @@ type UpdateStaffValues struct {
 	IsActive bool
 	RoleName string
 }
+
+type UpdateStaffProfileValues struct {
+	ID       uuid.UUID
+	PhotoURL *string
+}


### PR DESCRIPTION
✨ Changes Made

  - Added general image upload endpoint (POST /upload/image) that accepts multipart files and uploads to GCP storage
  - Implemented staff profile update endpoint (PATCH /staff/{id}/profile) with photo URL support
  - Added role-based security so users can only update their own profiles unless they're admin
  - Fixed missing contextUtils import causing compilation error in staff handler

  ---
  🧠 Reason for Changes

  User requested a complete profile picture upload system with proper security restrictions for staff and athlete
  profile updates.

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
Example: `https://trello.com/c/your-task-id`

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

