### PR TITLE
[Fix] GCP path names and the upload/image endpoints

### DIFF
--- a/cmd/server/server/main.go
+++ b/cmd/server/server/main.go
@@ -122,8 +122,8 @@ func setupMiddlewares(router *chi.Mux) {
 	router.Use(middlewares.SetJSONContentType)
 
 	router.Use(cors.New(cors.Options{
-		AllowedOrigins:   []string{"https://rise-web-461776259687.us-west2.run.app", "*"}, // * is used but should be replaced when going to prod
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedOrigins:   []string{"https://rise-web-461776259687.us-west2.run.app", "http://localhost:3000"}, // Added localhost:3000 for frontend development
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"}, // Added PATCH method
 		AllowedHeaders:   []string{"Content-Type", "Authorization"},
 		ExposedHeaders:   []string{"Authorization"},
 		AllowCredentials: true,


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- 
- Fixed GCP path names and the upload/image endpoints
- Enabled cors to be allowed for localhost 3000, get rid of this in prod
- 

---

# 🧠 Reason for Changes

Our images were not being organized correctly and the forntend couldnt send proper requests to our backend through CORS

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/GDWuNcFG/336-fix-gcp-organization-and-fix-cors

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

