### PR TITLE
  [Feature] Add credit allocation on membership purchase

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -482,6 +482,7 @@ func RegisterSecureCreditRoutes(container *di.Container) func(chi.Router) {
 	return func(r chi.Router) {
 		r.With(middlewares.JWTAuthMiddleware(true)).Get("/", h.GetCustomerCredits)
 		r.With(middlewares.JWTAuthMiddleware(true)).Get("/transactions", h.GetCustomerCreditTransactions)
+		r.With(middlewares.JWTAuthMiddleware(true)).Get("/weekly-usage", h.GetWeeklyUsage)
 	}
 }
 

--- a/db/migrations/20250917164500_add_credit_fields_to_membership_plans.sql
+++ b/db/migrations/20250917164500_add_credit_fields_to_membership_plans.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Add optional credit allocation and weekly limit fields to membership plans
+-- These are only used for credit-based memberships, NULL for traditional memberships
+ALTER TABLE membership.membership_plans 
+ADD COLUMN credit_allocation INTEGER NULL,
+ADD COLUMN weekly_credit_limit INTEGER NULL;
+
+-- Add comments to explain the fields
+COMMENT ON COLUMN membership.membership_plans.credit_allocation IS 'Number of credits awarded when purchasing this membership plan (NULL for non-credit memberships)';
+COMMENT ON COLUMN membership.membership_plans.weekly_credit_limit IS 'Maximum credits that can be used per week with this membership plan (NULL for non-credit memberships, 0 = unlimited credits)';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Remove the credit fields
+ALTER TABLE membership.membership_plans 
+DROP COLUMN IF EXISTS credit_allocation,
+DROP COLUMN IF EXISTS weekly_credit_limit;
+
+-- +goose StatementEnd

--- a/db/migrations/20250917164600_create_weekly_credit_usage_table.sql
+++ b/db/migrations/20250917164600_create_weekly_credit_usage_table.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Create table to track weekly credit usage per customer
+CREATE TABLE IF NOT EXISTS users.weekly_credit_usage (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    customer_id UUID NOT NULL REFERENCES users.users(id) ON DELETE CASCADE,
+    week_start_date DATE NOT NULL, -- Monday of the week (ISO week)
+    credits_used INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    
+    -- Ensure one record per customer per week
+    CONSTRAINT unique_customer_week UNIQUE (customer_id, week_start_date)
+);
+
+-- Add indexes for efficient querying
+CREATE INDEX IF NOT EXISTS idx_weekly_credit_usage_customer_id ON users.weekly_credit_usage (customer_id);
+CREATE INDEX IF NOT EXISTS idx_weekly_credit_usage_week_start ON users.weekly_credit_usage (week_start_date);
+CREATE INDEX IF NOT EXISTS idx_weekly_credit_usage_customer_week ON users.weekly_credit_usage (customer_id, week_start_date);
+
+-- Add comments
+COMMENT ON TABLE users.weekly_credit_usage IS 'Tracks weekly credit consumption per customer for membership limit enforcement';
+COMMENT ON COLUMN users.weekly_credit_usage.week_start_date IS 'Monday of the ISO week (e.g., 2024-01-15 for week starting Jan 15)';
+COMMENT ON COLUMN users.weekly_credit_usage.credits_used IS 'Total credits consumed during this week';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Remove indexes
+DROP INDEX IF EXISTS idx_weekly_credit_usage_customer_id;
+DROP INDEX IF EXISTS idx_weekly_credit_usage_week_start;
+DROP INDEX IF EXISTS idx_weekly_credit_usage_customer_week;
+
+-- Remove table
+DROP TABLE IF EXISTS users.weekly_credit_usage;
+
+-- +goose StatementEnd

--- a/internal/domains/event/dto/event_response.go
+++ b/internal/domains/event/dto/event_response.go
@@ -59,13 +59,16 @@ type (
 	}
 
 	EventResponseDto struct {
-		ID        uuid.UUID         `json:"id"`
-		Program   ProgramInfo       `json:"program"`
-		Location  LocationInfo      `json:"location"`
-		Capacity  int32             `json:"capacity"`
-		CreatedBy PersonResponseDto `json:"created_by"`
-		UpdatedBy PersonResponseDto `json:"updated_by"`
-		Team      *TeamInfo         `json:"team,omitempty"`
+		ID                       uuid.UUID         `json:"id"`
+		Program                  ProgramInfo       `json:"program"`
+		Location                 LocationInfo      `json:"location"`
+		Capacity                 int32             `json:"capacity"`
+		CreatedBy                PersonResponseDto `json:"created_by"`
+		UpdatedBy                PersonResponseDto `json:"updated_by"`
+		Team                     *TeamInfo         `json:"team,omitempty"`
+		RequiredMembershipPlanID *uuid.UUID        `json:"required_membership_plan_id,omitempty"`
+		PriceID                  *string           `json:"price_id,omitempty"`
+		CreditCost               *int32            `json:"credit_cost,omitempty"`
 		DateResponseDto
 		*Participants
 	}
@@ -73,10 +76,13 @@ type (
 
 func NewEventResponseDto(event values.ReadEventValues, includePeople bool) EventResponseDto {
 	response := EventResponseDto{
-		ID:        event.ID,
-		Capacity:  event.Capacity,
-		CreatedBy: PersonResponseDto(event.CreatedBy),
-		UpdatedBy: PersonResponseDto(event.UpdatedBy),
+		ID:                       event.ID,
+		Capacity:                 event.Capacity,
+		CreatedBy:                PersonResponseDto(event.CreatedBy),
+		UpdatedBy:                PersonResponseDto(event.UpdatedBy),
+		RequiredMembershipPlanID: event.RequiredMembershipPlanID,
+		PriceID:                  event.PriceID,
+		CreditCost:               event.CreditCost,
 		Location: LocationInfo{
 			ID:      event.Location.ID,
 			Name:    event.Location.Name,

--- a/internal/domains/event/dto/requests.go
+++ b/internal/domains/event/dto/requests.go
@@ -37,6 +37,7 @@ type EventRequestDto struct {
 	TeamID                   uuid.UUID `json:"team_id" example:"0bab3927-50eb-42b3-9d6b-2350dd00a100"`
 	RequiredMembershipPlanID uuid.UUID `json:"required_membership_plan_id" example:"f0e21457-75d4-4de6-b765-5ee13221fd72"`
 	PriceID                  string    `json:"price_id" example:"price_123"`
+	CreditCost               *int32    `json:"credit_cost" validate:"omitempty,gte=0" example:"5"`
 }
 
 type DeleteRequestDto struct {
@@ -193,6 +194,7 @@ func (dto EventRequestDto) ToCreateEventValues(creator uuid.UUID) (values.Create
 			TeamID:                   dto.TeamID,
 			RequiredMembershipPlanID: dto.RequiredMembershipPlanID,
 			PriceID:                  dto.PriceID,
+			CreditCost:               dto.CreditCost,
 		},
 	}
 
@@ -222,6 +224,7 @@ func (dto EventRequestDto) ToUpdateEventValues(idStr string, updater uuid.UUID) 
 			TeamID:                   dto.TeamID,
 			RequiredMembershipPlanID: dto.RequiredMembershipPlanID,
 			PriceID:                  dto.PriceID,
+			CreditCost:               dto.CreditCost,
 		},
 	}
 

--- a/internal/domains/event/values/event.go
+++ b/internal/domains/event/values/event.go
@@ -17,6 +17,7 @@ type EventDetails struct {
 	TeamID                   uuid.UUID
 	RequiredMembershipPlanID uuid.UUID
 	PriceID                  string
+	CreditCost               *int32
 }
 
 type CreateEventValues struct {

--- a/internal/domains/membership/dto/membership_plan/requests.go
+++ b/internal/domains/membership/dto/membership_plan/requests.go
@@ -13,6 +13,8 @@ type PlanRequestDto struct {
 	AmtPeriods          *int32    `json:"amt_periods" validate:"omitempty,gt=0"`
 	StripePriceID       string    `json:"stripe_price_id" validate:"required,notwhitespace"`
 	StripeJoiningFeesID string    `json:"stripe_joining_fees_id"`
+	CreditAllocation    *int32    `json:"credit_allocation" validate:"omitempty,gte=0"`
+	WeeklyCreditLimit   *int32    `json:"weekly_credit_limit" validate:"omitempty,gte=0"`
 }
 
 func (dto PlanRequestDto) ToCreateValueObjects() (values.PlanCreateValues, *errLib.CommonError) {
@@ -31,6 +33,8 @@ func (dto PlanRequestDto) ToCreateValueObjects() (values.PlanCreateValues, *errL
 			AmtPeriods:          dto.AmtPeriods,
 			StripeJoiningFeesID: dto.StripeJoiningFeesID,
 			StripePriceID:       dto.StripePriceID,
+			CreditAllocation:    dto.CreditAllocation,
+			WeeklyCreditLimit:   dto.WeeklyCreditLimit,
 		},
 	}
 
@@ -60,6 +64,8 @@ func (dto PlanRequestDto) ToUpdateValueObjects(planIdStr string) (values.PlanUpd
 			AmtPeriods:          dto.AmtPeriods,
 			StripeJoiningFeesID: dto.StripeJoiningFeesID,
 			StripePriceID:       dto.StripePriceID,
+			CreditAllocation:    dto.CreditAllocation,
+			WeeklyCreditLimit:   dto.WeeklyCreditLimit,
 		},
 	}, nil
 }

--- a/internal/domains/membership/dto/membership_plan/responses.go
+++ b/internal/domains/membership/dto/membership_plan/responses.go
@@ -16,6 +16,8 @@ type PlanResponse struct {
 	StripePriceID       string    `json:"stripe_price_id"`
 	StripeJoiningFeesID *string   `json:"stripe_joining_fees_id,omitempty"`
 	AmtPeriods          *int32    `json:"amt_periods,omitempty"`
+	CreditAllocation    *int32    `json:"credit_allocation,omitempty"`
+	WeeklyCreditLimit   *int32    `json:"weekly_credit_limit,omitempty"`
 	UnitAmount          int       `json:"unit_amount"`
 	Currency            string    `json:"currency"`
 	Interval            string    `json:"interval"`
@@ -37,6 +39,8 @@ func NewPlanResponse(plan values.PlanReadValues) PlanResponse {
 		StripePriceID:       plan.StripePriceID,
 		StripeJoiningFeesID: getPtrIfNotEmpty(plan.StripeJoiningFeesID),
 		AmtPeriods:          plan.AmtPeriods,
+		CreditAllocation:    plan.CreditAllocation,
+		WeeklyCreditLimit:   plan.WeeklyCreditLimit,
 		UnitAmount:          plan.UnitAmount,
 		Currency:            strings.ToUpper(plan.Currency), // e.g. "USD", "CAD"
 		Interval:            plan.Interval, // e.g. "month", "year", weekly, etc.

--- a/internal/domains/membership/persistence/repositories/plans.go
+++ b/internal/domains/membership/persistence/repositories/plans.go
@@ -55,6 +55,20 @@ func (r *PlansRepository) CreateMembershipPlan(c context.Context, membershipPlan
 			Valid: true,
 		}
 	}
+	
+	if membershipPlan.CreditAllocation != nil {
+		dbParams.CreditAllocation = sql.NullInt32{
+			Int32: *membershipPlan.CreditAllocation,
+			Valid: true,
+		}
+	}
+	
+	if membershipPlan.WeeklyCreditLimit != nil {
+		dbParams.WeeklyCreditLimit = sql.NullInt32{
+			Int32: *membershipPlan.WeeklyCreditLimit,
+			Valid: true,
+		}
+	}
 
 	_, err := r.Queries.CreateMembershipPlan(c, dbParams)
 
@@ -105,6 +119,12 @@ func (r *PlansRepository) GetMembershipPlanById(ctx context.Context, id uuid.UUI
 	if dbPlan.AmtPeriods.Valid {
 		plan.AmtPeriods = &dbPlan.AmtPeriods.Int32
 	}
+	if dbPlan.CreditAllocation.Valid {
+		plan.CreditAllocation = &dbPlan.CreditAllocation.Int32
+	}
+	if dbPlan.WeeklyCreditLimit.Valid {
+		plan.WeeklyCreditLimit = &dbPlan.WeeklyCreditLimit.Int32
+	}
 
 	return plan, nil
 }
@@ -137,6 +157,12 @@ func (r *PlansRepository) GetMembershipPlans(ctx context.Context, membershipId u
 
 		if dbPlan.AmtPeriods.Valid {
 			plan.AmtPeriods = &dbPlan.AmtPeriods.Int32
+		}
+		if dbPlan.CreditAllocation.Valid {
+			plan.CreditAllocation = &dbPlan.CreditAllocation.Int32
+		}
+		if dbPlan.WeeklyCreditLimit.Valid {
+			plan.WeeklyCreditLimit = &dbPlan.WeeklyCreditLimit.Int32
 		}
 		if dbPlan.UnitAmount.Valid {
 			plan.UnitAmount = int(dbPlan.UnitAmount.Int32)
@@ -173,6 +199,20 @@ func (r *PlansRepository) UpdateMembershipPlan(c context.Context, plan values.Pl
 	if plan.AmtPeriods != nil {
 		dbMembershipParams.AmtPeriods = sql.NullInt32{
 			Int32: *plan.AmtPeriods,
+			Valid: true,
+		}
+	}
+	
+	if plan.CreditAllocation != nil {
+		dbMembershipParams.CreditAllocation = sql.NullInt32{
+			Int32: *plan.CreditAllocation,
+			Valid: true,
+		}
+	}
+	
+	if plan.WeeklyCreditLimit != nil {
+		dbMembershipParams.WeeklyCreditLimit = sql.NullInt32{
+			Int32: *plan.WeeklyCreditLimit,
 			Valid: true,
 		}
 	}

--- a/internal/domains/membership/persistence/sqlc/generated/models.go
+++ b/internal/domains/membership/persistence/sqlc/generated/models.go
@@ -593,6 +593,10 @@ type MembershipMembershipPlan struct {
 	Interval           sql.NullString `json:"interval"`
 	// One-time joining fee in cents (e.g., 13000 = $130.00). Applied as Stripe setup fee on first payment only.
 	JoiningFee int32 `json:"joining_fee"`
+	// Number of credits awarded when purchasing this membership plan (NULL for non-credit memberships)
+	CreditAllocation sql.NullInt32 `json:"credit_allocation"`
+	// Maximum credits that can be used per week with this membership plan (NULL for non-credit memberships, 0 = unlimited credits)
+	WeeklyCreditLimit sql.NullInt32 `json:"weekly_credit_limit"`
 }
 
 type PlaygroundSession struct {
@@ -765,6 +769,18 @@ type UsersUser struct {
 	Dob                      time.Time      `json:"dob"`
 	IsArchived               bool           `json:"is_archived"`
 	SquareCustomerID         sql.NullString `json:"square_customer_id"`
+}
+
+// Tracks weekly credit consumption per customer for membership limit enforcement
+type UsersWeeklyCreditUsage struct {
+	ID         uuid.UUID `json:"id"`
+	CustomerID uuid.UUID `json:"customer_id"`
+	// Monday of the ISO week (e.g., 2024-01-15 for week starting Jan 15)
+	WeekStartDate time.Time `json:"week_start_date"`
+	// Total credits consumed during this week
+	CreditsUsed int32        `json:"credits_used"`
+	CreatedAt   sql.NullTime `json:"created_at"`
+	UpdatedAt   sql.NullTime `json:"updated_at"`
 }
 
 type WaiverWaiver struct {

--- a/internal/domains/membership/persistence/sqlc/generated/plans.sql.go
+++ b/internal/domains/membership/persistence/sqlc/generated/plans.sql.go
@@ -14,9 +14,9 @@ import (
 )
 
 const createMembershipPlan = `-- name: CreateMembershipPlan :one
-INSERT INTO membership.membership_plans (membership_id, name, stripe_joining_fee_id, stripe_price_id, amt_periods, joining_fee)
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval, joining_fee
+INSERT INTO membership.membership_plans (membership_id, name, stripe_joining_fee_id, stripe_price_id, amt_periods, joining_fee, credit_allocation, weekly_credit_limit)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+RETURNING id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval, joining_fee, credit_allocation, weekly_credit_limit
 `
 
 type CreateMembershipPlanParams struct {
@@ -26,6 +26,8 @@ type CreateMembershipPlanParams struct {
 	StripePriceID      string         `json:"stripe_price_id"`
 	AmtPeriods         sql.NullInt32  `json:"amt_periods"`
 	JoiningFee         int32          `json:"joining_fee"`
+	CreditAllocation   sql.NullInt32  `json:"credit_allocation"`
+	WeeklyCreditLimit  sql.NullInt32  `json:"weekly_credit_limit"`
 }
 
 func (q *Queries) CreateMembershipPlan(ctx context.Context, arg CreateMembershipPlanParams) (MembershipMembershipPlan, error) {
@@ -36,6 +38,8 @@ func (q *Queries) CreateMembershipPlan(ctx context.Context, arg CreateMembership
 		arg.StripePriceID,
 		arg.AmtPeriods,
 		arg.JoiningFee,
+		arg.CreditAllocation,
+		arg.WeeklyCreditLimit,
 	)
 	var i MembershipMembershipPlan
 	err := row.Scan(
@@ -51,6 +55,8 @@ func (q *Queries) CreateMembershipPlan(ctx context.Context, arg CreateMembership
 		&i.Currency,
 		&i.Interval,
 		&i.JoiningFee,
+		&i.CreditAllocation,
+		&i.WeeklyCreditLimit,
 	)
 	return i, err
 }
@@ -68,7 +74,7 @@ func (q *Queries) DeleteMembershipPlan(ctx context.Context, id uuid.UUID) (int64
 }
 
 const getMembershipPlanById = `-- name: GetMembershipPlanById :one
-SELECT id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval, joining_fee
+SELECT id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval, joining_fee, credit_allocation, weekly_credit_limit
 FROM membership.membership_plans
 WHERE id = $1
 `
@@ -89,6 +95,8 @@ func (q *Queries) GetMembershipPlanById(ctx context.Context, id uuid.UUID) (Memb
 		&i.Currency,
 		&i.Interval,
 		&i.JoiningFee,
+		&i.CreditAllocation,
+		&i.WeeklyCreditLimit,
 	)
 	return i, err
 }
@@ -105,6 +113,8 @@ SELECT
   mp.currency,
   mp.interval,
   mp.joining_fee,
+  mp.credit_allocation,
+  mp.weekly_credit_limit,
   mp.created_at,
   mp.updated_at
 FROM membership.membership_plans mp
@@ -122,6 +132,8 @@ type GetMembershipPlansRow struct {
 	Currency           sql.NullString `json:"currency"`
 	Interval           sql.NullString `json:"interval"`
 	JoiningFee         int32          `json:"joining_fee"`
+	CreditAllocation   sql.NullInt32  `json:"credit_allocation"`
+	WeeklyCreditLimit  sql.NullInt32  `json:"weekly_credit_limit"`
 	CreatedAt          time.Time      `json:"created_at"`
 	UpdatedAt          time.Time      `json:"updated_at"`
 }
@@ -146,6 +158,8 @@ func (q *Queries) GetMembershipPlans(ctx context.Context, membershipID uuid.UUID
 			&i.Currency,
 			&i.Interval,
 			&i.JoiningFee,
+			&i.CreditAllocation,
+			&i.WeeklyCreditLimit,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -170,9 +184,11 @@ SET name              = $1,
     amt_periods       = $4,
     membership_id     = $5,
     joining_fee       = $6,
+    credit_allocation = $7,
+    weekly_credit_limit = $8,
     updated_at        = CURRENT_TIMESTAMP
-WHERE id = $7
-RETURNING id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval, joining_fee
+WHERE id = $9
+RETURNING id, name, stripe_price_id, stripe_joining_fee_id, membership_id, amt_periods, created_at, updated_at, unit_amount, currency, interval, joining_fee, credit_allocation, weekly_credit_limit
 `
 
 type UpdateMembershipPlanParams struct {
@@ -182,6 +198,8 @@ type UpdateMembershipPlanParams struct {
 	AmtPeriods         sql.NullInt32  `json:"amt_periods"`
 	MembershipID       uuid.UUID      `json:"membership_id"`
 	JoiningFee         int32          `json:"joining_fee"`
+	CreditAllocation   sql.NullInt32  `json:"credit_allocation"`
+	WeeklyCreditLimit  sql.NullInt32  `json:"weekly_credit_limit"`
 	ID                 uuid.UUID      `json:"id"`
 }
 
@@ -193,6 +211,8 @@ func (q *Queries) UpdateMembershipPlan(ctx context.Context, arg UpdateMembership
 		arg.AmtPeriods,
 		arg.MembershipID,
 		arg.JoiningFee,
+		arg.CreditAllocation,
+		arg.WeeklyCreditLimit,
 		arg.ID,
 	)
 	var i MembershipMembershipPlan
@@ -209,6 +229,8 @@ func (q *Queries) UpdateMembershipPlan(ctx context.Context, arg UpdateMembership
 		&i.Currency,
 		&i.Interval,
 		&i.JoiningFee,
+		&i.CreditAllocation,
+		&i.WeeklyCreditLimit,
 	)
 	return i, err
 }

--- a/internal/domains/membership/persistence/sqlc/queries/plans.sql
+++ b/internal/domains/membership/persistence/sqlc/queries/plans.sql
@@ -1,6 +1,6 @@
 -- name: CreateMembershipPlan :one
-INSERT INTO membership.membership_plans (membership_id, name, stripe_joining_fee_id, stripe_price_id, amt_periods, joining_fee)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO membership.membership_plans (membership_id, name, stripe_joining_fee_id, stripe_price_id, amt_periods, joining_fee, credit_allocation, weekly_credit_limit)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 RETURNING *;
 
 -- name: GetMembershipPlanById :one
@@ -20,6 +20,8 @@ SELECT
   mp.currency,
   mp.interval,
   mp.joining_fee,
+  mp.credit_allocation,
+  mp.weekly_credit_limit,
   mp.created_at,
   mp.updated_at
 FROM membership.membership_plans mp
@@ -34,8 +36,10 @@ SET name              = $1,
     amt_periods       = $4,
     membership_id     = $5,
     joining_fee       = $6,
+    credit_allocation = $7,
+    weekly_credit_limit = $8,
     updated_at        = CURRENT_TIMESTAMP
-WHERE id = $7
+WHERE id = $9
 RETURNING *;
 
 -- name: DeleteMembershipPlan :execrows

--- a/internal/domains/membership/values/plans.go
+++ b/internal/domains/membership/values/plans.go
@@ -13,6 +13,8 @@ type PlanDetails struct {
 	StripeJoiningFeesID string
 	StripePriceID       string
 	JoiningFee          int
+	CreditAllocation    *int32
+	WeeklyCreditLimit   *int32
 }
 
 type PlanCreateValues struct {

--- a/internal/domains/payment/handler/checkout.go
+++ b/internal/domains/payment/handler/checkout.go
@@ -182,7 +182,7 @@ func (h *CheckoutHandlers) GetEventEnrollmentOptions(w http.ResponseWriter, r *h
 // @Accept json
 // @Produce json
 // @Param id path string true "Event ID" format(uuid)
-// @Param request body map[string]interface{} false "Payment method request" example({"payment_method":"stripe"})
+// @Param request body map[string]interface{} false "Payment method request" example({"payment_method":"stripe"}) enum("stripe","credits")
 // @Success 200 {object} dto.CheckoutResponseDto "Payment link generated or free enrollment completed"
 // @Failure 400 {object} map[string]interface{} "Bad Request: Invalid input or missing event ID"
 // @Failure 404 {object} map[string]interface{} "Not Found: Event not found"

--- a/internal/domains/user/handler/staff_handler.go
+++ b/internal/domains/user/handler/staff_handler.go
@@ -28,7 +28,7 @@ func NewStaffHandlers(container *di.Container) *StaffHandler {
 }
 
 // GetStaffs retrieves a list of staff members based on optional role filter.
-// @Tags staff
+// @Tags staffs
 // @Accept json
 // @Produce json
 // @Param role query string false "Role name to filter staff" example("Coach")
@@ -64,7 +64,7 @@ func (h *StaffHandler) GetStaffs(w http.ResponseWriter, r *http.Request) {
 }
 
 // UpdateStaff updates an existing staff member.
-// @Tags staff
+// @Tags staffs
 // @Accept json
 // @Produce json
 // @Param id path string true "Staff ID" example("f47ac10b-58cc-4372-a567-0e02b2c3d479")
@@ -128,7 +128,7 @@ func (h *StaffHandler) UpdateStaff(w http.ResponseWriter, r *http.Request) {
 }
 
 // DeleteStaff deletes a staff member by ID.
-// @Tags staff
+// @Tags staffs
 // @Accept json
 // @Produce json
 // @Param id path string true "Staff ID" example("f47ac10b-58cc-4372-a567-0e02b2c3d479")
@@ -156,7 +156,7 @@ func (h *StaffHandler) DeleteStaff(w http.ResponseWriter, r *http.Request) {
 }
 
 // UpdateStaffProfile updates staff profile information like photo URL.
-// @Tags staff
+// @Tags staffs
 // @Accept json
 // @Produce json
 // @Security Bearer

--- a/internal/domains/user/persistence/sqlc/generated/models.go
+++ b/internal/domains/user/persistence/sqlc/generated/models.go
@@ -592,6 +592,10 @@ type MembershipMembershipPlan struct {
 	Interval           sql.NullString `json:"interval"`
 	// One-time joining fee in cents (e.g., 13000 = $130.00). Applied as Stripe setup fee on first payment only.
 	JoiningFee int32 `json:"joining_fee"`
+	// Number of credits awarded when purchasing this membership plan (NULL for non-credit memberships)
+	CreditAllocation sql.NullInt32 `json:"credit_allocation"`
+	// Maximum credits that can be used per week with this membership plan (NULL for non-credit memberships, 0 = unlimited credits)
+	WeeklyCreditLimit sql.NullInt32 `json:"weekly_credit_limit"`
 }
 
 type PlaygroundSession struct {
@@ -764,6 +768,18 @@ type UsersUser struct {
 	Dob                      time.Time      `json:"dob"`
 	IsArchived               bool           `json:"is_archived"`
 	SquareCustomerID         sql.NullString `json:"square_customer_id"`
+}
+
+// Tracks weekly credit consumption per customer for membership limit enforcement
+type UsersWeeklyCreditUsage struct {
+	ID         uuid.UUID `json:"id"`
+	CustomerID uuid.UUID `json:"customer_id"`
+	// Monday of the ISO week (e.g., 2024-01-15 for week starting Jan 15)
+	WeekStartDate time.Time `json:"week_start_date"`
+	// Total credits consumed during this week
+	CreditsUsed int32        `json:"credits_used"`
+	CreatedAt   sql.NullTime `json:"created_at"`
+	UpdatedAt   sql.NullTime `json:"updated_at"`
 }
 
 type WaiverWaiver struct {

--- a/internal/domains/user/persistence/sqlc/queries/credit.sql
+++ b/internal/domains/user/persistence/sqlc/queries/credit.sql
@@ -73,3 +73,62 @@ WHERE id = $1;
 UPDATE events.events
 SET credit_cost = $2
 WHERE id = $1;
+
+-- Weekly Credit Usage Queries
+
+-- name: GetWeeklyCreditsUsed :one
+-- Get customer's credit usage for the current week
+SELECT COALESCE(credits_used, 0) as credits_used
+FROM users.weekly_credit_usage
+WHERE customer_id = $1 
+  AND week_start_date = $2;
+
+-- name: UpdateWeeklyCreditsUsed :exec
+-- Update (or insert) weekly credit usage for a customer
+INSERT INTO users.weekly_credit_usage (customer_id, week_start_date, credits_used, updated_at)
+VALUES ($1, $2, $3, NOW())
+ON CONFLICT (customer_id, week_start_date) 
+DO UPDATE SET 
+    credits_used = users.weekly_credit_usage.credits_used + EXCLUDED.credits_used,
+    updated_at = NOW();
+
+-- name: GetActiveCustomerMembershipPlanID :one
+-- Get customer's active membership plan ID
+SELECT membership_plan_id
+FROM users.customer_membership_plans
+WHERE customer_id = $1 
+  AND status = 'active'
+ORDER BY created_at DESC
+LIMIT 1;
+
+-- name: GetCustomerMembershipPlan :one
+-- Get customer's current membership plan with credit info
+SELECT mp.credit_allocation, mp.weekly_credit_limit
+FROM users.customer_membership_plans cmp
+JOIN membership.membership_plans mp ON cmp.membership_plan_id = mp.id
+WHERE cmp.customer_id = $1 
+  AND cmp.status = 'active'
+ORDER BY cmp.created_at DESC
+LIMIT 1;
+
+-- name: CheckWeeklyCreditLimit :one
+-- Check if customer can use specified credits without exceeding weekly limit
+SELECT 
+    COALESCE(wcu.credits_used, 0) as current_usage,
+    mp.weekly_credit_limit,
+    CASE 
+        WHEN mp.weekly_credit_limit IS NULL THEN true  -- Non-credit membership
+        WHEN mp.weekly_credit_limit = 0 THEN true      -- Unlimited credits
+        WHEN COALESCE(wcu.credits_used, 0) + $3 <= mp.weekly_credit_limit THEN true
+        ELSE false
+    END as can_use_credits
+FROM users.customer_membership_plans cmp
+JOIN membership.membership_plans mp ON cmp.membership_plan_id = mp.id
+LEFT JOIN users.weekly_credit_usage wcu ON (
+    wcu.customer_id = $1 AND 
+    wcu.week_start_date = $2
+)
+WHERE cmp.customer_id = $1 
+  AND cmp.status = 'active'
+ORDER BY cmp.created_at DESC
+LIMIT 1;

--- a/internal/domains/user/services/credit_service.go
+++ b/internal/domains/user/services/credit_service.go
@@ -1,0 +1,200 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"time"
+
+	"api/internal/di"
+	dbUser "api/internal/domains/user/persistence/sqlc/generated"
+	dbMembership "api/internal/domains/membership/persistence/sqlc/generated"
+	errLib "api/internal/libs/errors"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+type CreditService struct {
+	UserQueries       *dbUser.Queries
+	MembershipQueries *dbMembership.Queries
+}
+
+func NewCreditService(container *di.Container) *CreditService {
+	return &CreditService{
+		UserQueries:       container.Queries.UserDb,
+		MembershipQueries: container.Queries.MembershipDb,
+	}
+}
+
+// GetCurrentWeekStart returns the Monday of the current week (ISO week)
+func (s *CreditService) GetCurrentWeekStart() time.Time {
+	now := time.Now()
+	
+	// Get the weekday (0 = Sunday, 1 = Monday, ..., 6 = Saturday)
+	weekday := now.Weekday()
+	
+	// Calculate days since Monday (ISO week starts on Monday)
+	daysSinceMonday := int(weekday-time.Monday) % 7
+	if daysSinceMonday < 0 {
+		daysSinceMonday += 7
+	}
+	
+	// Get Monday of this week
+	monday := now.AddDate(0, 0, -daysSinceMonday)
+	
+	// Return Monday at midnight
+	return time.Date(monday.Year(), monday.Month(), monday.Day(), 0, 0, 0, 0, monday.Location())
+}
+
+// CanUseCredits checks if a customer can use the specified number of credits
+// without exceeding their membership's weekly limit
+func (s *CreditService) CanUseCredits(ctx context.Context, customerID uuid.UUID, creditsToUse int32) (bool, *errLib.CommonError) {
+	weekStart := s.GetCurrentWeekStart()
+	
+	result, err := s.UserQueries.CheckWeeklyCreditLimit(ctx, dbUser.CheckWeeklyCreditLimitParams{
+		CustomerID:    customerID,
+		WeekStartDate: weekStart,
+		CreditsUsed:   creditsToUse,
+	})
+	
+	if err != nil {
+		// If no membership plan found, assume they can't use credits
+		return false, errLib.New("No active membership plan found", http.StatusBadRequest)
+	}
+	
+	return result.CanUseCredits, nil
+}
+
+// GetWeeklyUsage returns the customer's current weekly credit usage and their limit
+func (s *CreditService) GetWeeklyUsage(ctx context.Context, customerID uuid.UUID) (int32, *int32, *errLib.CommonError) {
+	weekStart := s.GetCurrentWeekStart()
+	
+	// Get current usage
+	usage, err := s.UserQueries.GetWeeklyCreditsUsed(ctx, dbUser.GetWeeklyCreditsUsedParams{
+		CustomerID:    customerID,
+		WeekStartDate: weekStart,
+	})
+	
+	if err != nil {
+		usage = 0 // No usage record exists yet
+	}
+	
+	// Get customer's active membership plan ID
+	membershipPlanID, err := s.getUserActiveMembershipPlanID(ctx, customerID)
+	if err != nil {
+		log.Printf("Failed to get active membership plan ID for customer %s: %v", customerID, err)
+		return usage, nil, errLib.New("No active membership plan found", http.StatusBadRequest)
+	}
+	log.Printf("Found membership plan ID %s for customer %s", membershipPlanID, customerID)
+	
+	// Get membership plan details from membership database
+	membershipPlan, err := s.MembershipQueries.GetMembershipPlanById(ctx, membershipPlanID)
+	if err != nil {
+		log.Printf("Failed to get membership plan details for plan %s: %v", membershipPlanID, err)
+		return usage, nil, errLib.New("Membership plan not found", http.StatusBadRequest)
+	}
+	log.Printf("Found membership plan: credit_allocation=%v, weekly_limit=%v", 
+		membershipPlan.CreditAllocation, membershipPlan.WeeklyCreditLimit)
+	
+	var weeklyLimit *int32
+	if membershipPlan.WeeklyCreditLimit.Valid {
+		weeklyLimit = &membershipPlan.WeeklyCreditLimit.Int32
+	}
+	
+	return usage, weeklyLimit, nil
+}
+
+// UseCredits deducts credits and updates weekly usage tracking
+func (s *CreditService) UseCredits(ctx context.Context, customerID uuid.UUID, creditsToUse int32, description string) *errLib.CommonError {
+	// Check if they can use the credits
+	canUse, err := s.CanUseCredits(ctx, customerID, creditsToUse)
+	if err != nil {
+		return err
+	}
+	
+	if !canUse {
+		return errLib.New("Weekly credit limit exceeded", http.StatusBadRequest)
+	}
+	
+	// Deduct from customer's credit balance
+	rowsAffected, dbErr := s.UserQueries.DeductCredits(ctx, dbUser.DeductCreditsParams{
+		CustomerID: customerID,
+		Credits:    creditsToUse,
+	})
+	
+	if dbErr != nil {
+		return errLib.New("Failed to deduct credits", http.StatusInternalServerError)
+	}
+	
+	if rowsAffected == 0 {
+		return errLib.New("Insufficient credits", http.StatusBadRequest)
+	}
+	
+	// Update weekly usage tracking
+	weekStart := s.GetCurrentWeekStart()
+	dbErr = s.UserQueries.UpdateWeeklyCreditsUsed(ctx, dbUser.UpdateWeeklyCreditsUsedParams{
+		CustomerID:    customerID,
+		WeekStartDate: weekStart,
+		CreditsUsed:   creditsToUse,
+	})
+	
+	if dbErr != nil {
+		// Log the error but don't fail the transaction - the credits were already deducted
+		// In production, you might want to implement compensating actions
+		return errLib.New("Failed to update weekly usage tracking", http.StatusInternalServerError)
+	}
+	
+	return nil
+}
+
+// AllocateCreditsOnMembershipPurchase awards credits when a customer purchases a membership
+func (s *CreditService) AllocateCreditsOnMembershipPurchase(ctx context.Context, customerID uuid.UUID, membershipPlanID uuid.UUID) *errLib.CommonError {
+	// Get the membership plan to see how many credits to allocate
+	plan, err := s.MembershipQueries.GetMembershipPlanById(ctx, membershipPlanID)
+	if err != nil {
+		return errLib.New("Membership plan not found", http.StatusNotFound)
+	}
+	
+	// Only allocate credits if this is a credit-based membership
+	if plan.CreditAllocation.Valid && plan.CreditAllocation.Int32 > 0 {
+		// Add credits to customer's account
+		_, err = s.UserQueries.RefundCredits(ctx, dbUser.RefundCreditsParams{
+			CustomerID: customerID,
+			Credits:    plan.CreditAllocation.Int32,
+		})
+		
+		if err != nil {
+			return errLib.New("Failed to allocate membership credits", http.StatusInternalServerError)
+		}
+		
+		// Log the credit transaction
+		description := "Credits allocated for membership purchase"
+		
+		err = s.UserQueries.LogCreditTransaction(ctx, dbUser.LogCreditTransactionParams{
+			CustomerID:      customerID,
+			Amount:          plan.CreditAllocation.Int32,
+			TransactionType: dbUser.CreditTransactionTypeEnrollment,
+			EventID:         uuid.NullUUID{Valid: false}, // No event associated
+			Description:     sql.NullString{String: description, Valid: true},
+		})
+		
+		if err != nil {
+			// Log error but don't fail - credits were already allocated
+			return errLib.New("Failed to log credit transaction", http.StatusInternalServerError)
+		}
+	}
+	
+	return nil
+}
+
+// getUserActiveMembershipPlanID gets the customer's active membership plan ID
+func (s *CreditService) getUserActiveMembershipPlanID(ctx context.Context, customerID uuid.UUID) (uuid.UUID, error) {
+	// This should be a simple query to users.customer_membership_plans table
+	// We'll add this query to the user database queries
+	rows, err := s.UserQueries.GetActiveCustomerMembershipPlanID(ctx, customerID)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return rows, nil
+}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
  - Implemented credit allocation system that awards credits on membership purchase via Stripe webhooks
  - Added weekly credit usage limits with ISO week tracking (Monday-Sunday cycles)
  - Created credit-based event enrollment with automatic deduction and weekly limit validation
  - Built comprehensive credit management APIs (balance, transactions, weekly usage, admin controls)
  - Added credit cost field to events with full DTO and Swagger documentation support
  - Integrated credit payment option alongside existing Stripe and membership-based enrollment methods

---

# 🧠 Reason for Changes

  Enable flexible payment options for customers by supporting credit-based memberships alongside traditional
  payments. This allows members to purchase credit bundles and use them for event enrollment while maintaining
  weekly usage limits to prevent abuse. The system provides complete audit trails and admin controls for credit
  management.

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/DpIHjaOG/330-add-credit-memberships-and-credit-restrictions-for-those-memberships

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

