### PR TITLE
Add live Stripe price fetching for membership plans and joining fees

### DIFF
--- a/internal/domains/membership/dto/membership_plan/responses.go
+++ b/internal/domains/membership/dto/membership_plan/responses.go
@@ -22,15 +22,14 @@ type PlanResponse struct {
 	Currency            string    `json:"currency"`
 	Interval            string    `json:"interval"`
 	Price               string    `json:"price"`
-	JoiningFee          int       `json:"joining_fee"`
-	JoiningFeeDisplay   string    `json:"joining_fee_display"`
+	JoiningFeePrice     string    `json:"joining_fee_price"`
 	CreatedAt           time.Time `json:"created_at"`
 	UpdatedAt           time.Time `json:"updated_at"`
 }
 
 func NewPlanResponse(plan values.PlanReadValues) PlanResponse {
 	displayPrice := fmt.Sprintf("$%.2f", float64(plan.UnitAmount)/100) // convert unit_amount to dollars and format as string
-	joiningFeeDisplay := fmt.Sprintf("$%.2f", float64(plan.JoiningFee)/100) // convert joining_fee to dollars and format as string
+	joiningFeePrice := fmt.Sprintf("$%.2f", float64(plan.JoiningFee)/100) // convert joining_fee to dollars and format as string
 
 	return PlanResponse{
 		MembershipID:        plan.MembershipID,
@@ -45,8 +44,7 @@ func NewPlanResponse(plan values.PlanReadValues) PlanResponse {
 		Currency:            strings.ToUpper(plan.Currency), // e.g. "USD", "CAD"
 		Interval:            plan.Interval, // e.g. "month", "year", weekly, etc.
 		Price:               displayPrice, // e.g. "$10.00" display price
-		JoiningFee:          plan.JoiningFee,
-		JoiningFeeDisplay:   joiningFeeDisplay, // e.g. "$130.00" display price
+		JoiningFeePrice:     joiningFeePrice, // e.g. "$130.00" display price
 		CreatedAt:           plan.CreatedAt,
 		UpdatedAt:           plan.UpdatedAt,
 	}

--- a/internal/domains/membership/handler/plans.go
+++ b/internal/domains/membership/handler/plans.go
@@ -77,7 +77,7 @@ func (h *PlansHandlers) GetMembershipPlans(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	plans, err := h.Service.GetPlans(r.Context(), membershipId)
+	plans, err := h.Service.GetPlansWithStripeData(r.Context(), membershipId)
 
 	if err != nil {
 		responseHandlers.RespondWithError(w, err)

--- a/internal/domains/payment/services/stripe/stripe.go
+++ b/internal/domains/payment/services/stripe/stripe.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stripe/stripe-go/v81/checkout/session"
 	"github.com/stripe/stripe-go/v81/coupon"
 	"github.com/stripe/stripe-go/v81/customer"
+	"github.com/stripe/stripe-go/v81/price"
 	"github.com/stripe/stripe-go/v81/subscription"
 	"github.com/stripe/stripe-go/v81/webhook"
 )
@@ -707,4 +708,27 @@ func ValidateWebhookSignature(payload []byte, signature, secret string) (*stripe
 	}
 
 	return &event, nil
+}
+
+// PriceService handles Stripe price operations
+type PriceService struct{}
+
+// NewPriceService creates a new price service instance
+func NewPriceService() *PriceService {
+	return &PriceService{}
+}
+
+// GetPrice retrieves a price from Stripe by price ID
+func (s *PriceService) GetPrice(priceID string) (*stripe.Price, *errLib.CommonError) {
+	if strings.TrimSpace(priceID) == "" {
+		return nil, errLib.New("price ID cannot be empty", http.StatusBadRequest)
+	}
+
+	stripePrice, err := price.Get(priceID, nil)
+	if err != nil {
+		log.Printf("[STRIPE] Failed to get price %s: %v", priceID, err)
+		return nil, errLib.New("Failed to retrieve price from Stripe: "+err.Error(), http.StatusInternalServerError)
+	}
+
+	return stripePrice, nil
 }


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
  - Added live Stripe price fetching for membership plans using stripe_price_id
  - Added live Stripe joining fee price fetching using stripe_joining_fee_id
  - Removed redundant joining_fee and joining_fee_display fields from response DTO

---

# 🧠 Reason for Changes

  Membership plans were showing stale pricing data from the database instead of live Stripe prices, causing pricing
  discrepancies for customers.

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
Example: `https://trello.com/c/your-task-id`

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

