### PR TITLE
[Feature] Add customer account deletion endpoint 

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -119,6 +119,7 @@ func RegisterCustomerRoutes(container *di.Container) func(chi.Router) {
 		r.Post("/{id}/archive", h.ArchiveCustomer)
 		r.Post("/{id}/unarchive", h.UnarchiveCustomer)
 		r.Get("/archived", h.ListArchivedCustomers)
+		r.With(middlewares.JWTAuthMiddleware(true)).Delete("/delete-account", h.DeleteMyAccount)
 	}
 }
 
@@ -471,6 +472,7 @@ func RegisterSecureCustomerRoutes(container *di.Container) func(chi.Router) {
 	h := userHandler.NewCustomersHandler(container)
 	return func(r chi.Router) {
 		r.With(middlewares.JWTAuthMiddleware(true)).Get("/memberships", h.GetUserMembershipHistory)
+		r.With(middlewares.JWTAuthMiddleware(true)).Delete("/delete-account", h.DeleteMyAccount)
 	}
 }
 

--- a/internal/domains/identity/service/firebase/firebase.go
+++ b/internal/domains/identity/service/firebase/firebase.go
@@ -40,3 +40,22 @@ func (s *Service) GetUserEmail(ctx context.Context, firebaseIdToken string) (str
 
 	return user.Email, nil
 }
+
+func (s *Service) DeleteUser(ctx context.Context, userEmail string) *errLib.CommonError {
+	// Get user by email first
+	user, firebaseErr := s.FirebaseAuthClient.GetUserByEmail(ctx, userEmail)
+	if firebaseErr != nil {
+		log.Printf("Failed to get Firebase user by email %s: %v", userEmail, firebaseErr)
+		return errLib.New("Firebase user not found", http.StatusNotFound)
+	}
+
+	// Delete the user from Firebase
+	firebaseErr = s.FirebaseAuthClient.DeleteUser(ctx, user.UID)
+	if firebaseErr != nil {
+		log.Printf("Failed to delete Firebase user %s: %v", user.UID, firebaseErr)
+		return errLib.New("Failed to delete Firebase user", http.StatusInternalServerError)
+	}
+
+	log.Printf("Successfully deleted Firebase user: %s (%s)", user.UID, userEmail)
+	return nil
+}

--- a/internal/domains/user/dto/customer/account_deletion.go
+++ b/internal/domains/user/dto/customer/account_deletion.go
@@ -1,0 +1,6 @@
+package customer
+
+// AccountDeletionRequest represents the request to delete a customer account
+type AccountDeletionRequest struct {
+	ConfirmDeletion bool `json:"confirm_deletion" binding:"required" example:"true"`
+}

--- a/internal/domains/user/persistence/repository/user_repository.go
+++ b/internal/domains/user/persistence/repository/user_repository.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"log"
@@ -68,7 +67,7 @@ func (r *UsersRepository) UpdateUser(ctx context.Context, details values.UpdateV
 				return errLib.New("hubspot id already exists", http.StatusConflict)
 			}
 		}
-		log.Println(fmt.Sprintf("Error updating user: %s", err))
+		log.Printf("Error updating user: %s", err)
 		return errLib.New("internal error while updating user", http.StatusInternalServerError)
 	}
 

--- a/internal/domains/user/persistence/sqlc/generated/customer.sql.go
+++ b/internal/domains/user/persistence/sqlc/generated/customer.sql.go
@@ -91,6 +91,68 @@ func (q *Queries) CreateAthleteInfo(ctx context.Context, arg CreateAthleteInfoPa
 	return result.RowsAffected()
 }
 
+const deleteAthleteData = `-- name: DeleteAthleteData :execrows
+
+DELETE FROM athletic.athletes WHERE id = $1
+`
+
+// Note: credit_transactions has ON DELETE CASCADE, so it will be cleaned automatically
+func (q *Queries) DeleteAthleteData(ctx context.Context, id uuid.UUID) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteAthleteData, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteCustomerAccount = `-- name: DeleteCustomerAccount :execrows
+DELETE FROM users.users WHERE id = $1
+`
+
+func (q *Queries) DeleteCustomerAccount(ctx context.Context, id uuid.UUID) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteCustomerAccount, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteCustomerEnrollments = `-- name: DeleteCustomerEnrollments :execrows
+DELETE FROM program.customer_enrollment WHERE customer_id = $1
+`
+
+func (q *Queries) DeleteCustomerEnrollments(ctx context.Context, customerID uuid.UUID) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteCustomerEnrollments, customerID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteCustomerEventEnrollments = `-- name: DeleteCustomerEventEnrollments :execrows
+DELETE FROM events.customer_enrollment WHERE customer_id = $1
+`
+
+func (q *Queries) DeleteCustomerEventEnrollments(ctx context.Context, customerID uuid.UUID) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteCustomerEventEnrollments, customerID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteCustomerMemberships = `-- name: DeleteCustomerMemberships :execrows
+DELETE FROM users.customer_membership_plans WHERE customer_id = $1
+`
+
+func (q *Queries) DeleteCustomerMemberships(ctx context.Context, customerID uuid.UUID) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteCustomerMemberships, customerID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const getActiveMembershipInfo = `-- name: GetActiveMembershipInfo :one
 SELECT
     cmp.id,

--- a/internal/domains/user/persistence/sqlc/generated/models.go
+++ b/internal/domains/user/persistence/sqlc/generated/models.go
@@ -518,6 +518,17 @@ type GameGame struct {
 	CourtID    uuid.NullUUID  `json:"court_id"`
 }
 
+type HaircutBarberAvailability struct {
+	ID        uuid.UUID `json:"id"`
+	BarberID  uuid.UUID `json:"barber_id"`
+	DayOfWeek int32     `json:"day_of_week"`
+	StartTime time.Time `json:"start_time"`
+	EndTime   time.Time `json:"end_time"`
+	IsActive  bool      `json:"is_active"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 type HaircutBarberService struct {
 	ID        uuid.UUID `json:"id"`
 	BarberID  uuid.UUID `json:"barber_id"`
@@ -596,6 +607,15 @@ type MembershipMembershipPlan struct {
 	CreditAllocation sql.NullInt32 `json:"credit_allocation"`
 	// Maximum credits that can be used per week with this membership plan (NULL for non-credit memberships, 0 = unlimited credits)
 	WeeklyCreditLimit sql.NullInt32 `json:"weekly_credit_limit"`
+}
+
+type NotificationsPushToken struct {
+	ID            int32          `json:"id"`
+	UserID        uuid.UUID      `json:"user_id"`
+	ExpoPushToken string         `json:"expo_push_token"`
+	DeviceType    sql.NullString `json:"device_type"`
+	CreatedAt     sql.NullTime   `json:"created_at"`
+	UpdatedAt     sql.NullTime   `json:"updated_at"`
 }
 
 type PlaygroundSession struct {

--- a/internal/domains/user/persistence/sqlc/queries/customer.sql
+++ b/internal/domains/user/persistence/sqlc/queries/customer.sql
@@ -193,3 +193,20 @@ SELECT u.*
 FROM users.users u
 WHERE u.is_archived = TRUE
 LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
+
+-- name: DeleteCustomerAccount :execrows
+DELETE FROM users.users WHERE id = $1;
+
+-- name: DeleteCustomerMemberships :execrows
+DELETE FROM users.customer_membership_plans WHERE customer_id = $1;
+
+-- name: DeleteCustomerEnrollments :execrows
+DELETE FROM program.customer_enrollment WHERE customer_id = $1;
+
+-- name: DeleteCustomerEventEnrollments :execrows  
+DELETE FROM events.customer_enrollment WHERE customer_id = $1;
+
+-- Note: credit_transactions has ON DELETE CASCADE, so it will be cleaned automatically
+
+-- name: DeleteAthleteData :execrows
+DELETE FROM athletic.athletes WHERE id = $1;


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
  - Add DELETE /secure/customers/delete-account endpoint for self-service account deletion
  - Implement comprehensive data cleanup across all related tables (memberships, enrollments, credits, staff
  records)
  - Integrate Firebase user deletion and Stripe subscription cancellation during account deletion

---

# 🧠 Reason for Changes

Apple requested ability for customers to delete their own accounts with complete data removal from all systems.

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/Tw4XQDpR/341-add-delete-endpoint-for-customers

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

