### PR TITLE
[fix]  Fixed the /secure/customers/memberships endpoint

### DIFF
--- a/internal/domains/user/dto/customer/response.go
+++ b/internal/domains/user/dto/customer/response.go
@@ -63,6 +63,7 @@ type MembershipHistoryResponse struct {
 	Price                 string     `json:"price"`
 	StartDate             time.Time  `json:"start_date"`
 	RenewalDate           *time.Time `json:"renewal_date,omitempty"`
+	NextPaymentDate       *time.Time `json:"next_payment_date,omitempty"`
 	Status                string     `json:"status"`
 }
 
@@ -75,6 +76,7 @@ func MembershipHistoryValueToResponse(v values.MembershipHistoryValue) Membershi
 		Price:                 price,
 		StartDate:             v.StartDate,
 		RenewalDate:           v.RenewalDate,
+		NextPaymentDate:       v.NextPaymentDate,
 		Status:                v.Status,
 		MembsershipBenefits:   v.MembershipBenefits,
 	}

--- a/internal/domains/user/persistence/repository/customer_repository.go
+++ b/internal/domains/user/persistence/repository/customer_repository.go
@@ -446,6 +446,7 @@ func (r *CustomerRepository) ListMembershipHistory(ctx context.Context, customer
 				}
 				return ""
 			}(row.Interval),
+			StripePriceID: row.StripePriceID,
 		}
 	}
 

--- a/internal/domains/user/persistence/sqlc/generated/models.go
+++ b/internal/domains/user/persistence/sqlc/generated/models.go
@@ -788,6 +788,7 @@ type UsersUser struct {
 	Dob                      time.Time      `json:"dob"`
 	IsArchived               bool           `json:"is_archived"`
 	SquareCustomerID         sql.NullString `json:"square_customer_id"`
+	StripeCustomerID         sql.NullString `json:"stripe_customer_id"`
 }
 
 // Tracks weekly credit consumption per customer for membership limit enforcement

--- a/internal/domains/user/persistence/sqlc/generated/staff.sql.go
+++ b/internal/domains/user/persistence/sqlc/generated/staff.sql.go
@@ -79,7 +79,7 @@ func (q *Queries) GetAvailableStaffRoles(ctx context.Context) ([]StaffStaffRole,
 }
 
 const getStaffs = `-- name: GetStaffs :many
-SELECT s.is_active, u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, sr.role_name, cs.wins, cs.losses, s.photo_url
+SELECT s.is_active, u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, sr.role_name, cs.wins, cs.losses, s.photo_url
 FROM staff.staff s
 JOIN users.users u ON u.id = s.id
 JOIN staff.staff_roles sr ON s.role_id = sr.id
@@ -105,6 +105,7 @@ type GetStaffsRow struct {
 	Dob                      time.Time      `json:"dob"`
 	IsArchived               bool           `json:"is_archived"`
 	SquareCustomerID         sql.NullString `json:"square_customer_id"`
+	StripeCustomerID         sql.NullString `json:"stripe_customer_id"`
 	RoleName                 string         `json:"role_name"`
 	Wins                     sql.NullInt32  `json:"wins"`
 	Losses                   sql.NullInt32  `json:"losses"`
@@ -138,6 +139,7 @@ func (q *Queries) GetStaffs(ctx context.Context, roleName sql.NullString) ([]Get
 			&i.Dob,
 			&i.IsArchived,
 			&i.SquareCustomerID,
+			&i.StripeCustomerID,
 			&i.RoleName,
 			&i.Wins,
 			&i.Losses,

--- a/internal/domains/user/persistence/sqlc/queries/customer.sql
+++ b/internal/domains/user/persistence/sqlc/queries/customer.sql
@@ -169,7 +169,8 @@ SELECT
     mp.name AS membership_plan_name,
     mp.unit_amount,
     mp.currency,
-    mp.interval
+    mp.interval,
+    mp.stripe_price_id
 FROM users.customer_membership_plans cmp
     JOIN membership.membership_plans mp ON mp.id = cmp.membership_plan_id
     JOIN membership.memberships m ON m.id = mp.membership_id

--- a/internal/domains/user/values/customer.go
+++ b/internal/domains/user/values/customer.go
@@ -63,6 +63,7 @@ type MembershipHistoryValue struct {
 	CustomerID            uuid.UUID
 	StartDate             time.Time
 	RenewalDate           *time.Time
+	NextPaymentDate       *time.Time
 	Status                string
 	CreatedAt             time.Time
 	UpdatedAt             time.Time
@@ -75,4 +76,5 @@ type MembershipHistoryValue struct {
 	UnitAmount            int
 	Currency              string
 	Interval              string
+	StripePriceID         string
 }


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
  - Fixed /secure/customers/memberships endpoint to show live Stripe pricing instead of $0.00
  - Added missing StripePriceID field mapping in the repository layer
  - Added separate next_payment_date field to distinguish between membership renewal and billing cycles

---

# 🧠 Reason for Changes

  The customer memberships endpoint was showing incorrect $0 pricing because the repository wasn't mapping the stripe_price_id from the
  database query to the values struct. We also needed to separate renewal dates (when membership expires) from payment dates (when next
  billing occurs) to give users clear information about both their membership status and upcoming charges.

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
Example: `https://trello.com/c/your-task-id`

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

