### PR TITLE
[Fix] Add credit cost support for events

### DIFF
--- a/internal/domains/event/dto/requests.go
+++ b/internal/domains/event/dto/requests.go
@@ -25,6 +25,7 @@ type RecurrenceRequestDto struct {
 	TeamID                   uuid.UUID `json:"team_id" example:"0bab3927-50eb-42b3-9d6b-2350dd00a100"`
 	RequiredMembershipPlanID uuid.UUID `json:"required_membership_plan_id" example:"f0e21457-75d4-4de6-b765-5ee13221fd72"`
 	PriceID                  string    `json:"price_id" example:"price_123"`
+	CreditCost               *int32    `json:"credit_cost" validate:"omitempty,gte=0" example:"5"`
 }
 
 //goland:noinspection GoNameStartsWithPackageName
@@ -87,6 +88,7 @@ func (dto RecurrenceRequestDto) ToCreateRecurrenceValues(creator uuid.UUID) (val
 		ProgramID:                dto.ProgramID,
 		RequiredMembershipPlanID: dto.RequiredMembershipPlanID,
 		PriceID:                  dto.PriceID,
+		CreditCost:               dto.CreditCost,
 	}
 
 	return createRecurrenceValues, nil
@@ -108,6 +110,7 @@ func (dto RecurrenceRequestDto) ToUpdateRecurrenceValues(updater, recurrenceID u
 		ProgramID:                dto.ProgramID,
 		RequiredMembershipPlanID: dto.RequiredMembershipPlanID,
 		PriceID:                  dto.PriceID,
+		CreditCost:               dto.CreditCost,
 	}
 
 	return updateRecurrenceValues, nil

--- a/internal/domains/event/persistence/sqlc/generated/models.go
+++ b/internal/domains/event/persistence/sqlc/generated/models.go
@@ -518,6 +518,17 @@ type GameGame struct {
 	CourtID    uuid.NullUUID  `json:"court_id"`
 }
 
+type HaircutBarberAvailability struct {
+	ID        uuid.UUID `json:"id"`
+	BarberID  uuid.UUID `json:"barber_id"`
+	DayOfWeek int32     `json:"day_of_week"`
+	StartTime time.Time `json:"start_time"`
+	EndTime   time.Time `json:"end_time"`
+	IsActive  bool      `json:"is_active"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 type HaircutBarberService struct {
 	ID        uuid.UUID `json:"id"`
 	BarberID  uuid.UUID `json:"barber_id"`
@@ -590,6 +601,21 @@ type MembershipMembershipPlan struct {
 	UnitAmount         sql.NullInt32  `json:"unit_amount"`
 	Currency           sql.NullString `json:"currency"`
 	Interval           sql.NullString `json:"interval"`
+	// One-time joining fee in cents (e.g., 13000 = $130.00). Applied as Stripe setup fee on first payment only.
+	JoiningFee int32 `json:"joining_fee"`
+	// Number of credits awarded when purchasing this membership plan (NULL for non-credit memberships)
+	CreditAllocation sql.NullInt32 `json:"credit_allocation"`
+	// Maximum credits that can be used per week with this membership plan (NULL for non-credit memberships, 0 = unlimited credits)
+	WeeklyCreditLimit sql.NullInt32 `json:"weekly_credit_limit"`
+}
+
+type NotificationsPushToken struct {
+	ID            int32          `json:"id"`
+	UserID        uuid.UUID      `json:"user_id"`
+	ExpoPushToken string         `json:"expo_push_token"`
+	DeviceType    sql.NullString `json:"device_type"`
+	CreatedAt     sql.NullTime   `json:"created_at"`
+	UpdatedAt     sql.NullTime   `json:"updated_at"`
 }
 
 type PlaygroundSession struct {
@@ -762,6 +788,21 @@ type UsersUser struct {
 	Dob                      time.Time      `json:"dob"`
 	IsArchived               bool           `json:"is_archived"`
 	SquareCustomerID         sql.NullString `json:"square_customer_id"`
+	StripeCustomerID         sql.NullString `json:"stripe_customer_id"`
+	// Staff notes about the customer for internal reference
+	Notes sql.NullString `json:"notes"`
+}
+
+// Tracks weekly credit consumption per customer for membership limit enforcement
+type UsersWeeklyCreditUsage struct {
+	ID         uuid.UUID `json:"id"`
+	CustomerID uuid.UUID `json:"customer_id"`
+	// Monday of the ISO week (e.g., 2024-01-15 for week starting Jan 15)
+	WeekStartDate time.Time `json:"week_start_date"`
+	// Total credits consumed during this week
+	CreditsUsed int32        `json:"credits_used"`
+	CreatedAt   sql.NullTime `json:"created_at"`
+	UpdatedAt   sql.NullTime `json:"updated_at"`
 }
 
 type WaiverWaiver struct {

--- a/internal/domains/event/persistence/sqlc/queries/event_queries.sql
+++ b/internal/domains/event/persistence/sqlc/queries/event_queries.sql
@@ -13,7 +13,8 @@ WITH unnested_data AS (
         unnest(sqlc.arg('is_cancelled_array')::bool[])           AS is_cancelled,
         unnest(sqlc.arg('cancellation_reasons')::text[])         AS cancellation_reason,
         unnest(sqlc.arg('required_membership_plan_ids')::uuid[]) AS required_membership_plan_id,
-        unnest(sqlc.arg('price_ids')::text[])                    AS price_id
+        unnest(sqlc.arg('price_ids')::text[])                    AS price_id,
+        unnest(sqlc.arg('credit_costs')::int[])                  AS credit_cost
 )
 INSERT INTO events.events (
     location_id,
@@ -29,7 +30,8 @@ INSERT INTO events.events (
     is_cancelled,
     cancellation_reason,
     required_membership_plan_id,
-    price_id
+    price_id,
+    credit_cost
 )
 SELECT
     location_id,
@@ -45,7 +47,8 @@ SELECT
     is_cancelled,
     NULLIF(cancellation_reason, ''),
     NULLIF(required_membership_plan_id, '00000000-0000-0000-0000-000000000000'::uuid),
-    NULLIF(price_id, '')
+    NULLIF(price_id, ''),
+    NULLIF(credit_cost, 0)
 FROM unnested_data
 ON CONFLICT ON CONSTRAINT no_overlapping_events DO NOTHING;
 
@@ -160,7 +163,8 @@ SET start_at                    = $1,
     updated_by                  = sqlc.arg('updated_by')::uuid,
     is_date_time_modified       = (recurrence_id IS NOT NULL),
     required_membership_plan_id = $10,
-    price_id                    = $11
+    price_id                    = $11,
+    credit_cost                 = $12
 WHERE id = $9
 RETURNING *;
 

--- a/internal/domains/event/service/service.go
+++ b/internal/domains/event/service/service.go
@@ -80,6 +80,7 @@ func (s *Service) CreateEvents(ctx context.Context, details values.CreateRecurre
 		details.RequiredMembershipPlanID,
 		details.PriceID,
 		details.DayOfWeek,
+		details.CreditCost,
 	)
 	if err != nil {
 		return err
@@ -171,6 +172,7 @@ func (s *Service) UpdateRecurringEvents(ctx context.Context, details values.Upda
 			details.RequiredMembershipPlanID,
 			details.PriceID,
 			details.DayOfWeek,
+			details.CreditCost,
 		)
 		if err != nil {
 			return err
@@ -251,6 +253,7 @@ func generateEventsFromRecurrence(
 	mutater, programID, locationID, courtID, teamID, membershipPlanID uuid.UUID,
 	priceID string,
 	day time.Weekday,
+	creditCost *int32,
 ) ([]values.CreateEventValues, *errLib.CommonError) {
 	const timeLayout = "15:04:05Z07:00"
 
@@ -295,6 +298,7 @@ func generateEventsFromRecurrence(
 				TeamID:                   teamID,
 				RequiredMembershipPlanID: membershipPlanID,
 				PriceID:                  priceID,
+				CreditCost:               creditCost,
 			},
 		})
 	}

--- a/internal/domains/event/service/service_test.go
+++ b/internal/domains/event/service/service_test.go
@@ -41,6 +41,7 @@ func TestGenerateEventsFromRecurrence(t *testing.T) {
 			recurrence.RequiredMembershipPlanID,
 			recurrence.PriceID,
 			recurrence.DayOfWeek,
+			nil,
 		)
 
 		assert.Nil(t, err)
@@ -86,6 +87,7 @@ func TestGenerateEventsFromRecurrence(t *testing.T) {
 			recurrence.RequiredMembershipPlanID,
 			recurrence.PriceID,
 			recurrence.DayOfWeek,
+			nil,
 		)
 
 		assert.Nil(t, events)
@@ -124,6 +126,7 @@ func TestGenerateEventsFromRecurrence(t *testing.T) {
 			recurrence.RequiredMembershipPlanID,
 			recurrence.PriceID,
 			recurrence.DayOfWeek,
+			nil,
 		)
 
 		assert.Nil(t, events)
@@ -162,6 +165,7 @@ func TestGenerateEventsFromRecurrence(t *testing.T) {
 			recurrence.RequiredMembershipPlanID,
 			recurrence.PriceID,
 			recurrence.DayOfWeek,
+			nil,
 		)
 
 		assert.Nil(t, err)
@@ -201,6 +205,7 @@ func TestGenerateEventsFromRecurrence(t *testing.T) {
 			recurrence.RequiredMembershipPlanID,
 			recurrence.PriceID,
 			recurrence.DayOfWeek,
+			nil,
 		)
 
 		assert.NotNil(t, err)
@@ -237,6 +242,7 @@ func TestGenerateEventsFromRecurrence(t *testing.T) {
 			recurrence.RequiredMembershipPlanID,
 			recurrence.PriceID,
 			recurrence.DayOfWeek,
+			nil,
 		)
 
 		assert.Nil(t, err)

--- a/internal/domains/event/values/recurrence.go
+++ b/internal/domains/event/values/recurrence.go
@@ -46,6 +46,7 @@ type CreateRecurrenceValues struct {
 	TeamID                   uuid.UUID
 	RequiredMembershipPlanID uuid.UUID
 	PriceID                  string
+	CreditCost               *int32
 }
 
 type UpdateRecurrenceValues struct {
@@ -58,4 +59,5 @@ type UpdateRecurrenceValues struct {
 	UpdatedBy                uuid.UUID
 	RequiredMembershipPlanID uuid.UUID
 	PriceID                  string
+	CreditCost               *int32
 }


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
  - Added credit_cost field support for one-time events
  - Added credit_cost field support for recurring events
  - Updated SQL queries, repository layer, DTOs, and tests to handle credit costs 

---

# 🧠 Reason for Changes

 Events need to support optional credit costs for customers, allowing events to be purchased using credits instead of or in addition to direct payment.

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
Example: `https://trello.com/c/your-task-id`

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

