### PR TITLE
Add court ID and name to event responses

### DIFF
--- a/internal/domains/event/dto/event_response.go
+++ b/internal/domains/event/dto/event_response.go
@@ -58,6 +58,11 @@ type (
 		Name string    `json:"name"`
 	}
 
+	CourtInfo struct {
+		ID   uuid.UUID `json:"id"`
+		Name string    `json:"name"`
+	}
+
 	EventResponseDto struct {
 		ID                       uuid.UUID         `json:"id"`
 		Program                  ProgramInfo       `json:"program"`
@@ -66,6 +71,7 @@ type (
 		CreatedBy                PersonResponseDto `json:"created_by"`
 		UpdatedBy                PersonResponseDto `json:"updated_by"`
 		Team                     *TeamInfo         `json:"team,omitempty"`
+		Court                    *CourtInfo        `json:"court,omitempty"`
 		RequiredMembershipPlanID *uuid.UUID        `json:"required_membership_plan_id,omitempty"`
 		PriceID                  *string           `json:"price_id,omitempty"`
 		CreditCost               *int32            `json:"credit_cost,omitempty"`
@@ -104,6 +110,13 @@ func NewEventResponseDto(event values.ReadEventValues, includePeople bool) Event
 		response.Team = &TeamInfo{
 			ID:   event.Team.ID,
 			Name: event.Team.Name,
+		}
+	}
+
+	if event.Court != nil {
+		response.Court = &CourtInfo{
+			ID:   event.Court.ID,
+			Name: event.Court.Name,
 		}
 	}
 

--- a/internal/domains/event/persistence/repository/event_repository.go
+++ b/internal/domains/event/persistence/repository/event_repository.go
@@ -206,6 +206,26 @@ func (r *EventsRepository) GetEvent(ctx context.Context, id uuid.UUID) (values.R
 		CreditCost:               nullInt32ToPtr(dbEvent.CreditCost),
 	}
 
+	if dbEvent.CourtID.Valid && dbEvent.CourtName.Valid {
+		eventValue.Court = &struct {
+			ID   uuid.UUID
+			Name string
+		}{
+			ID:   dbEvent.CourtID.UUID,
+			Name: dbEvent.CourtName.String,
+		}
+	}
+
+	if dbEvent.TeamID.Valid && dbEvent.TeamName.Valid {
+		eventValue.Team = &struct {
+			ID   uuid.UUID
+			Name string
+		}{
+			ID:   dbEvent.TeamID.UUID,
+			Name: dbEvent.TeamName.String,
+		}
+	}
+
 	dbStaffs, err := r.Queries.GetEventStaffs(ctx, id)
 	if err != nil {
 		log.Println("Failed to get event staffs from db: ", err.Error())
@@ -333,6 +353,16 @@ func (r *EventsRepository) GetEvents(ctx context.Context, filter values.GetEvent
 			}{
 				ID:   row.TeamID.UUID,
 				Name: row.TeamName.String,
+			}
+		}
+
+		if row.CourtID.Valid && row.CourtName.Valid {
+			event.Court = &struct {
+				ID   uuid.UUID
+				Name string
+			}{
+				ID:   row.CourtID.UUID,
+				Name: row.CourtName.String,
 			}
 		}
 

--- a/internal/domains/event/values/event.go
+++ b/internal/domains/event/values/event.go
@@ -69,6 +69,11 @@ type ReadEventValues struct {
 		Name string
 	}
 
+	Court *struct {
+		ID   uuid.UUID
+		Name string
+	}
+
 	RequiredMembershipPlanID *uuid.UUID
 	PriceID                  *string
 	CreditCost               *int32


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
  - Added Court field to ReadEventValues struct
  - Updated GetEvents and GetEvent repository methods to map court ID and name
  - Added CourtInfo type and court field to EventResponseDto

---

# 🧠 Reason for Changes

  Events need to include court information in API responses so clients can display which court an event is assigned
  to.

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
Example: `https://trello.com/c/your-task-id`

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

