### PR TITLE
[Feature] Added toggle visibility to the membership plans

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -213,6 +213,7 @@ func RegisterMembershipPlansRoutes(container *di.Container) func(chi.Router) {
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin)).Post("/", h.CreateMembershipPlan)
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin)).Put("/{id}", h.UpdateMembershipPlan)
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin)).Delete("/{id}", h.DeleteMembershipPlan)
+		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin)).Patch("/{id}/visibility", h.ToggleMembershipPlanVisibility)
 	}
 }
 

--- a/db/migrations/20251008070000_add_is_visible_to_membership_plans.sql
+++ b/db/migrations/20251008070000_add_is_visible_to_membership_plans.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Add is_visible column to membership_plans to allow hiding plans without deleting them
+ALTER TABLE membership.membership_plans
+ADD COLUMN is_visible BOOLEAN NOT NULL DEFAULT true;
+
+-- Add index for better query performance when filtering by visibility
+CREATE INDEX idx_membership_plans_is_visible ON membership.membership_plans(is_visible);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Remove the index and column
+DROP INDEX IF EXISTS membership.idx_membership_plans_is_visible;
+ALTER TABLE membership.membership_plans
+DROP COLUMN IF EXISTS is_visible;
+
+-- +goose StatementEnd

--- a/internal/domains/membership/handler/plans.go
+++ b/internal/domains/membership/handler/plans.go
@@ -160,3 +160,47 @@ func (h *PlansHandlers) DeleteMembershipPlan(w http.ResponseWriter, r *http.Requ
 
 	responseHandlers.RespondWithSuccess(w, nil, http.StatusNoContent)
 }
+
+// ToggleMembershipPlanVisibility toggles the visibility of a membership plan.
+// @Tags admin-membership-plans
+// @Accept json
+// @Produce json
+// @Param id path string true "Plan ID"
+// @Param visibility body map[string]bool true "Visibility status" example({"is_visible": true})
+// @Security Bearer
+// @Success 200 {object} membership_plan.PlanResponse "Membership plan visibility updated successfully"
+// @Failure 400 {object} map[string]interface{} "Bad Request: Invalid input"
+// @Failure 404 {object} map[string]interface{} "Not Found: Membership plan not found"
+// @Failure 500 {object} map[string]interface{} "Internal Server Error"
+// @Router /memberships/plans/{id}/visibility [patch]
+func (h *PlansHandlers) ToggleMembershipPlanVisibility(w http.ResponseWriter, r *http.Request) {
+
+	idStr := chi.URLParam(r, "id")
+
+	id, err := validators.ParseUUID(idStr)
+
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	var body struct {
+		IsVisible bool `json:"is_visible"`
+	}
+
+	if err := validators.ParseJSON(r.Body, &body); err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	plan, err := h.Service.ToggleMembershipPlanVisibility(r.Context(), id, body.IsVisible)
+
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	responseBody := membership_plan.NewPlanResponse(plan)
+
+	responseHandlers.RespondWithSuccess(w, responseBody, http.StatusOK)
+}

--- a/internal/domains/membership/persistence/sqlc/generated/models.go
+++ b/internal/domains/membership/persistence/sqlc/generated/models.go
@@ -519,6 +519,17 @@ type GameGame struct {
 	CourtID    uuid.NullUUID  `json:"court_id"`
 }
 
+type HaircutBarberAvailability struct {
+	ID        uuid.UUID `json:"id"`
+	BarberID  uuid.UUID `json:"barber_id"`
+	DayOfWeek int32     `json:"day_of_week"`
+	StartTime time.Time `json:"start_time"`
+	EndTime   time.Time `json:"end_time"`
+	IsActive  bool      `json:"is_active"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 type HaircutBarberService struct {
 	ID        uuid.UUID `json:"id"`
 	BarberID  uuid.UUID `json:"barber_id"`
@@ -597,6 +608,16 @@ type MembershipMembershipPlan struct {
 	CreditAllocation sql.NullInt32 `json:"credit_allocation"`
 	// Maximum credits that can be used per week with this membership plan (NULL for non-credit memberships, 0 = unlimited credits)
 	WeeklyCreditLimit sql.NullInt32 `json:"weekly_credit_limit"`
+	IsVisible         bool          `json:"is_visible"`
+}
+
+type NotificationsPushToken struct {
+	ID            int32          `json:"id"`
+	UserID        uuid.UUID      `json:"user_id"`
+	ExpoPushToken string         `json:"expo_push_token"`
+	DeviceType    sql.NullString `json:"device_type"`
+	CreatedAt     sql.NullTime   `json:"created_at"`
+	UpdatedAt     sql.NullTime   `json:"updated_at"`
 }
 
 type PlaygroundSession struct {
@@ -698,6 +719,21 @@ type StaffStaffRole struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// Available credit packages for one-time purchase
+type UsersCreditPackage struct {
+	ID          uuid.UUID      `json:"id"`
+	Name        string         `json:"name"`
+	Description sql.NullString `json:"description"`
+	// Stripe price ID for one-time payment checkout
+	StripePriceID string `json:"stripe_price_id"`
+	// Number of credits awarded when purchasing this package
+	CreditAllocation int32 `json:"credit_allocation"`
+	// Maximum credits that can be used per week (0 = unlimited)
+	WeeklyCreditLimit int32     `json:"weekly_credit_limit"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
+}
+
 type UsersCreditTransaction struct {
 	ID              uuid.UUID             `json:"id"`
 	CustomerID      uuid.UUID             `json:"customer_id"`
@@ -706,6 +742,19 @@ type UsersCreditTransaction struct {
 	EventID         uuid.NullUUID         `json:"event_id"`
 	Description     sql.NullString        `json:"description"`
 	CreatedAt       sql.NullTime          `json:"created_at"`
+}
+
+// Tracks each customer's currently active credit package and their weekly limit
+type UsersCustomerActiveCreditPackage struct {
+	// Customer who purchased the package (PRIMARY KEY ensures one package per customer)
+	CustomerID uuid.UUID `json:"customer_id"`
+	// The credit package they purchased
+	CreditPackageID uuid.UUID `json:"credit_package_id"`
+	// Weekly credit limit from the package (copied here for performance)
+	WeeklyCreditLimit int32 `json:"weekly_credit_limit"`
+	// When this package was purchased
+	PurchasedAt time.Time `json:"purchased_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 type UsersCustomerCredit struct {
@@ -769,6 +818,9 @@ type UsersUser struct {
 	Dob                      time.Time      `json:"dob"`
 	IsArchived               bool           `json:"is_archived"`
 	SquareCustomerID         sql.NullString `json:"square_customer_id"`
+	StripeCustomerID         sql.NullString `json:"stripe_customer_id"`
+	// Staff notes about the customer for internal reference
+	Notes sql.NullString `json:"notes"`
 }
 
 // Tracks weekly credit consumption per customer for membership limit enforcement

--- a/internal/domains/membership/persistence/sqlc/queries/plans.sql
+++ b/internal/domains/membership/persistence/sqlc/queries/plans.sql
@@ -9,7 +9,7 @@ FROM membership.membership_plans
 WHERE id = $1;
 
 -- name: GetMembershipPlans :many
-SELECT 
+SELECT
   mp.id,
   mp.membership_id,
   mp.name,
@@ -22,10 +22,12 @@ SELECT
   mp.joining_fee,
   mp.credit_allocation,
   mp.weekly_credit_limit,
+  mp.is_visible,
   mp.created_at,
   mp.updated_at
 FROM membership.membership_plans mp
-WHERE mp.membership_id = $1;
+WHERE mp.membership_id = $1
+  AND mp.is_visible = true;
 
 
 -- name: UpdateMembershipPlan :one
@@ -44,3 +46,30 @@ RETURNING *;
 
 -- name: DeleteMembershipPlan :execrows
 DELETE FROM membership.membership_plans WHERE id = $1;
+
+-- name: ToggleMembershipPlanVisibility :one
+UPDATE membership.membership_plans
+SET is_visible = $2,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = $1
+RETURNING *;
+
+-- name: GetAllMembershipPlansAdmin :many
+SELECT
+  mp.id,
+  mp.membership_id,
+  mp.name,
+  mp.stripe_price_id,
+  mp.stripe_joining_fee_id,
+  mp.amt_periods,
+  mp.unit_amount,
+  mp.currency,
+  mp.interval,
+  mp.joining_fee,
+  mp.credit_allocation,
+  mp.weekly_credit_limit,
+  mp.is_visible,
+  mp.created_at,
+  mp.updated_at
+FROM membership.membership_plans mp
+WHERE mp.membership_id = $1;

--- a/internal/domains/membership/values/plans.go
+++ b/internal/domains/membership/values/plans.go
@@ -29,6 +29,7 @@ type PlanUpdateValues struct {
 type PlanReadValues struct {
 	ID uuid.UUID
 	PlanDetails
+	IsVisible  bool
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 	UnitAmount int


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
  - Added is_visible column to membership_plans table
  - Added admin endpoint to toggle membership plan visibility (PATCH /memberships/plans/{id}/visibility)
  - Updated GetMembershipPlans query to only return visible plans to customers
  - Added swagger documentation for the new visibility endpoint

---

# 🧠 Reason for Changes

Some membership plans are only available during certain seasons (like summer camps).
  Instead of deleting and recreating these plans every year, admins can now just hide them with a checkbox when
  they're not in season, then show them again later. This saves time and keeps all the plan data intact.

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
Example: `https://trello.com/c/your-task-id`

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

