### PR TITLE
[fix] preventing double booking practices

### DIFF
--- a/db/migrations/20251015000001_add_practice_overlap_constraint.sql
+++ b/db/migrations/20251015000001_add_practice_overlap_constraint.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Enable the btree_gist extension for exclusion constraints
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- Create an immutable function to handle NULL end_time
+CREATE OR REPLACE FUNCTION practice.get_practice_end_time(start_time timestamptz, end_time timestamptz)
+RETURNS timestamptz
+LANGUAGE sql
+IMMUTABLE
+AS $$
+    SELECT COALESCE(end_time, start_time + interval '2 hours');
+$$;
+
+-- Add constraint to prevent overlapping practices on the same court
+-- This allows practices at the same time on different courts, but prevents double-booking the same court
+ALTER TABLE practice.practices
+ADD CONSTRAINT no_overlapping_practices
+EXCLUDE USING gist (
+    court_id WITH =,
+    tstzrange(start_time, practice.get_practice_end_time(start_time, end_time), '[)') WITH &&
+)
+WHERE (court_id IS NOT NULL);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Remove the overlapping practices constraint
+ALTER TABLE practice.practices
+DROP CONSTRAINT IF EXISTS no_overlapping_practices;
+
+-- Drop the helper function
+DROP FUNCTION IF EXISTS practice.get_practice_end_time(timestamptz, timestamptz);
+
+-- +goose StatementEnd


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- 
- 
- made a migration to prevent double bookings for practices on the same court

---

# 🧠 Reason for Changes
we cannot have two practcies booked at once on the same court
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
Example: `https://trello.com/c/your-task-id`

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

