### PR TITLE
[Bugfix] Pass registration_required to recurring event creation

### DIFF
--- a/docs/bugfixes/fix-recurring-event-registration-required.md
+++ b/docs/bugfixes/fix-recurring-event-registration-required.md
@@ -108,6 +108,29 @@ eventsToCreate, err := generateEventsFromRecurrence(
 )
 ```
 
+### 5. Updated unit tests (service_test.go)
+
+Added the new `registrationRequired` parameter to all 6 test cases in `internal/domains/event/service/service_test.go`:
+
+```go
+events, err := generateEventsFromRecurrence(
+    recurrence.FirstOccurrence,
+    recurrence.LastOccurrence,
+    recurrence.StartTime,
+    recurrence.EndTime,
+    recurrence.CreatedBy,
+    recurrence.ProgramID,
+    recurrence.LocationID,
+    recurrence.CourtID,
+    recurrence.TeamID,
+    recurrence.RequiredMembershipPlanIDs,
+    recurrence.PriceID,
+    recurrence.DayOfWeek,
+    nil,
+    true,  // <-- Added registrationRequired parameter
+)
+```
+
 ## Testing
 
 To verify the fix, create a recurring event with `registration_required: true`:

--- a/docs/bugfixes/fix-recurring-event-registration-required.md
+++ b/docs/bugfixes/fix-recurring-event-registration-required.md
@@ -1,0 +1,135 @@
+# Bug Fix: registration_required Ignored When Creating Recurring Events
+
+**Date:** 2025-12-02
+**Affected Endpoint:** `POST /events/recurring`
+**Severity:** Medium
+
+## Summary
+
+The `registration_required` field from the request payload was being ignored when creating recurring events. All created events would have `registration_required: false` regardless of the value sent in the request.
+
+## Root Cause
+
+The `generateEventsFromRecurrence` function in `internal/domains/event/service/service.go` was not accepting or passing the `registrationRequired` parameter to the individual events it created.
+
+**Data Flow Before Fix:**
+1. Request DTO correctly parsed `registration_required`
+2. DTO passed it to `CreateRecurrenceValues.RegistrationRequired`
+3. Service received it in `CreateEvents` via `details.RegistrationRequired`
+4. `generateEventsFromRecurrence` was called **without** `registrationRequired`
+5. Each generated event's `RegistrationRequired` defaulted to `false` (Go zero value)
+
+## Changes Made
+
+**File:** `internal/domains/event/service/service.go`
+
+### 1. Updated function signature (line 556-565)
+
+Added `registrationRequired bool` parameter:
+
+```go
+func generateEventsFromRecurrence(
+    firstOccurrence, lastOccurrence time.Time,
+    startTimeStr, endTimeStr string,
+    mutater, programID, locationID, courtID, teamID uuid.UUID,
+    membershipPlanIDs []uuid.UUID,
+    priceID string,
+    day time.Weekday,
+    creditCost *int32,
+    registrationRequired bool,  // <-- Added
+) ([]values.CreateEventValues, *errLib.CommonError)
+```
+
+### 2. Updated EventDetails creation (line 598-612)
+
+Added `RegistrationRequired` field to the generated events:
+
+```go
+events = append(events, values.CreateEventValues{
+    CreatedBy: mutater,
+    EventDetails: values.EventDetails{
+        StartAt:                   start,
+        EndAt:                     end,
+        ProgramID:                 programID,
+        LocationID:                locationID,
+        CourtID:                   courtID,
+        TeamID:                    teamID,
+        RequiredMembershipPlanIDs: membershipPlanIDs,
+        PriceID:                   priceID,
+        CreditCost:                creditCost,
+        RegistrationRequired:      registrationRequired,  // <-- Added
+    },
+})
+```
+
+### 3. Updated CreateEvents call (line 162-177)
+
+Passed `details.RegistrationRequired` to the function:
+
+```go
+events, err := generateEventsFromRecurrence(
+    details.FirstOccurrence,
+    details.LastOccurrence,
+    details.StartTime,
+    details.EndTime,
+    details.CreatedBy,
+    details.ProgramID,
+    details.LocationID,
+    details.CourtID,
+    details.TeamID,
+    details.RequiredMembershipPlanIDs,
+    details.PriceID,
+    details.DayOfWeek,
+    details.CreditCost,
+    details.RegistrationRequired,  // <-- Added
+)
+```
+
+### 4. Updated UpdateRecurringEvents call (line 390-405)
+
+Passed `details.RegistrationRequired` to the function:
+
+```go
+eventsToCreate, err := generateEventsFromRecurrence(
+    details.FirstOccurrence,
+    details.LastOccurrence,
+    details.StartTime,
+    details.EndTime,
+    details.UpdatedBy,
+    details.ProgramID,
+    details.LocationID,
+    details.CourtID,
+    details.TeamID,
+    details.RequiredMembershipPlanIDs,
+    details.PriceID,
+    details.DayOfWeek,
+    details.CreditCost,
+    details.RegistrationRequired,  // <-- Added
+)
+```
+
+## Testing
+
+To verify the fix, create a recurring event with `registration_required: true`:
+
+```json
+POST /events/recurring
+{
+  "program_id": "uuid",
+  "location_id": "uuid",
+  "recurrence_start_at": "2023-10-05T07:00:00Z",
+  "recurrence_end_at": "2023-10-30T07:00:00Z",
+  "event_start_at": "09:00:00+00:00",
+  "event_end_at": "10:00:00+00:00",
+  "day": "MONDAY",
+  "registration_required": true
+}
+```
+
+**Expected:** Each created event in the response should have `registration_required: true`
+
+## Notes
+
+- The one-time event creation (`POST /events/one-time`) was already working correctly
+- The default value for `registration_required` remains `true` when not provided (handled in DTO layer)
+- This fix also applies to `PUT /events/recurring/{id}` for updating recurring events

--- a/internal/domains/event/service/service.go
+++ b/internal/domains/event/service/service.go
@@ -173,6 +173,7 @@ func (s *Service) CreateEvents(ctx context.Context, details values.CreateRecurre
 		details.PriceID,
 		details.DayOfWeek,
 		details.CreditCost,
+		details.RegistrationRequired,
 	)
 	if err != nil {
 		return nil, err
@@ -400,6 +401,7 @@ func (s *Service) UpdateRecurringEvents(ctx context.Context, details values.Upda
 			details.PriceID,
 			details.DayOfWeek,
 			details.CreditCost,
+			details.RegistrationRequired,
 		)
 		if err != nil {
 			return err
@@ -561,6 +563,7 @@ func generateEventsFromRecurrence(
 	priceID string,
 	day time.Weekday,
 	creditCost *int32,
+	registrationRequired bool,
 ) ([]values.CreateEventValues, *errLib.CommonError) {
 	const timeLayout = "15:04:05Z07:00"
 
@@ -606,6 +609,7 @@ func generateEventsFromRecurrence(
 				RequiredMembershipPlanIDs: membershipPlanIDs,
 				PriceID:                   priceID,
 				CreditCost:                creditCost,
+				RegistrationRequired:      registrationRequired,
 			},
 		})
 	}

--- a/internal/domains/event/service/service_test.go
+++ b/internal/domains/event/service/service_test.go
@@ -42,6 +42,7 @@ func TestGenerateEventsFromRecurrence(t *testing.T) {
 			recurrence.PriceID,
 			recurrence.DayOfWeek,
 			nil,
+			true,
 		)
 
 		assert.Nil(t, err)
@@ -88,6 +89,7 @@ func TestGenerateEventsFromRecurrence(t *testing.T) {
 			recurrence.PriceID,
 			recurrence.DayOfWeek,
 			nil,
+			true,
 		)
 
 		assert.Nil(t, events)
@@ -127,6 +129,7 @@ func TestGenerateEventsFromRecurrence(t *testing.T) {
 			recurrence.PriceID,
 			recurrence.DayOfWeek,
 			nil,
+			true,
 		)
 
 		assert.Nil(t, events)
@@ -166,6 +169,7 @@ func TestGenerateEventsFromRecurrence(t *testing.T) {
 			recurrence.PriceID,
 			recurrence.DayOfWeek,
 			nil,
+			true,
 		)
 
 		assert.Nil(t, err)
@@ -206,6 +210,7 @@ func TestGenerateEventsFromRecurrence(t *testing.T) {
 			recurrence.PriceID,
 			recurrence.DayOfWeek,
 			nil,
+			true,
 		)
 
 		assert.NotNil(t, err)
@@ -243,6 +248,7 @@ func TestGenerateEventsFromRecurrence(t *testing.T) {
 			recurrence.PriceID,
 			recurrence.DayOfWeek,
 			nil,
+			true,
 		)
 
 		assert.Nil(t, err)


### PR DESCRIPTION
✨ Changes Made

  - Added registrationRequired parameter to generateEventsFromRecurrence function
  - Set RegistrationRequired field in generated EventDetails for each recurring event
  - Updated CreateEvents and UpdateRecurringEvents to pass registrationRequired to the generator function
  - Updated all 6 unit tests in service_test.go to include the new parameter

  ---
  🧠 Reason for Changes

  The registration_required field from the request payload was being ignored when creating recurring events via POST
   /events/recurring. All generated events defaulted to registration_required: false regardless of the value sent in
   the request.

  The root cause was that generateEventsFromRecurrence did not accept or use the registrationRequired parameter - it
   was properly parsed in the DTO layer but never passed through to the individual events being created. This fix
  ensures parity with one-time event creation (POST /events/one-time), which already handled this field correctly.

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [X] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [X] No server errors (Backend)

---


