### PR TITLE
[Feature] Improve audit logs and add photo_url to customer response

### DIFF
--- a/docs/bugfixes/audit-logs-and-customer-photo-url.md
+++ b/docs/bugfixes/audit-logs-and-customer-photo-url.md
@@ -1,0 +1,114 @@
+# Audit Logs Improvements & Customer Photo URL
+
+**Date:** 2025-12-02
+
+## Summary
+
+Improved staff activity audit logs to display human-readable names instead of UUIDs when deleting resources. Also added `photo_url` to customer API responses.
+
+## Changes Made
+
+### 1. Program Deletion Audit Log
+
+**File:** `internal/domains/program/service.go`
+
+**Before:**
+```go
+fmt.Sprintf("Deleted program with ID: %s", id)
+```
+
+**After:**
+```go
+// Fetch program name before deletion for audit log
+program, err := s.repo.GetProgramByID(ctx, id)
+if err != nil {
+    return err
+}
+// ...
+fmt.Sprintf("Deleted program '%s' (type: %s)", program.Name, program.Type)
+```
+
+**Audit log output:** `Deleted program 'Basketball Training' (type: course)`
+
+---
+
+### 2. Team Deletion Audit Log
+
+**File:** `internal/domains/team/service.go`
+
+**Before:**
+```go
+fmt.Sprintf("Deleted team with ID: %s", id)
+```
+
+**After:**
+```go
+// Fetch team before deletion for audit log and coach validation
+team, err := s.repo.GetByID(ctx, id)
+if err != nil {
+    return err
+}
+// ...
+fmt.Sprintf("Deleted team '%s'", team.TeamDetails.Name)
+```
+
+**Audit log output:** `Deleted team 'Warriors'`
+
+**Note:** The team fetch was moved outside the coach-only block so it runs for all users, enabling the audit log to capture the team name. The coach ownership validation still works the same way.
+
+---
+
+### 3. Location Deletion Audit Log
+
+**File:** `internal/domains/location/services/service.go`
+
+**Before:**
+```go
+fmt.Sprintf("Deleted location with ID: %s", id)
+```
+
+**After:**
+```go
+// Fetch location before deletion for audit log
+location, err := s.repo.GetLocationByID(ctx, id)
+if err != nil {
+    return err
+}
+// ...
+fmt.Sprintf("Deleted location '%s' at %s", location.Name, location.Address)
+```
+
+**Audit log output:** `Deleted location 'Main Gym' at 123 Sports Ave`
+
+---
+
+### 4. Customer Photo URL in Response
+
+**File:** `internal/domains/user/dto/customer/response.go`
+
+Added `PhotoURL` field to the `Response` struct:
+
+```go
+type Response struct {
+    // ... existing fields ...
+    PhotoURL                     *string                `json:"photo_url,omitempty"`
+    // ... existing fields ...
+}
+```
+
+Updated `UserReadValueToResponse` to include the photo URL from athlete info:
+
+```go
+if customer.AthleteInfo != nil && customer.AthleteInfo.PhotoURL != nil {
+    response.PhotoURL = customer.AthleteInfo.PhotoURL
+}
+```
+
+**Affected endpoints:**
+- `GET /customers/id/{id}`
+- `GET /customers`
+- `GET /customers/archived`
+
+## Testing
+
+No SQL regeneration or test updates required. All changes are in the service/DTO layer.

--- a/internal/domains/location/services/service.go
+++ b/internal/domains/location/services/service.go
@@ -108,6 +108,12 @@ func (s *Service) UpdateLocation(ctx context.Context, details values.UpdateDetai
 
 func (s *Service) DeleteLocation(ctx context.Context, id uuid.UUID) *errLib.CommonError {
 
+	// Fetch location before deletion for audit log
+	location, err := s.repo.GetLocationByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
 	return s.executeInTx(ctx, func(txRepo *repo.Repository) *errLib.CommonError {
 		if err := txRepo.DeleteLocation(ctx, id); err != nil {
 			return err
@@ -122,7 +128,7 @@ func (s *Service) DeleteLocation(ctx context.Context, id uuid.UUID) *errLib.Comm
 			ctx,
 			txRepo.GetTx(),
 			staffID,
-			fmt.Sprintf("Deleted location with ID: %s", id),
+			fmt.Sprintf("Deleted location '%s' at %s", location.Name, location.Address),
 		)
 	})
 }

--- a/internal/domains/program/service.go
+++ b/internal/domains/program/service.go
@@ -117,6 +117,12 @@ func (s *Service) UpdateProgram(ctx context.Context, details values.UpdateProgra
 
 func (s *Service) DeleteProgram(ctx context.Context, id uuid.UUID) *errLib.CommonError {
 
+	// Fetch program name before deletion for audit log
+	program, err := s.repo.GetProgramByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
 	return s.executeInTx(ctx, func(txRepo *repo.Repository) *errLib.CommonError {
 		if err := txRepo.Delete(ctx, id); err != nil {
 			return err
@@ -131,7 +137,7 @@ func (s *Service) DeleteProgram(ctx context.Context, id uuid.UUID) *errLib.Commo
 			ctx,
 			txRepo.GetTx(),
 			staffID,
-			fmt.Sprintf("Deleted program with ID: %s", id),
+			fmt.Sprintf("Deleted program '%s' (type: %s)", program.Name, program.Type),
 		)
 	})
 }

--- a/internal/domains/user/dto/customer/response.go
+++ b/internal/domains/user/dto/customer/response.go
@@ -22,6 +22,7 @@ type Response struct {
 	EmergencyContactPhone        *string                `json:"emergency_contact_phone,omitempty"`
 	EmergencyContactRelationship *string                `json:"emergency_contact_relationship,omitempty"`
 	MembershipInfo               *MembershipResponseDto `json:"membership_info,omitempty"`
+	PhotoURL                     *string                `json:"photo_url,omitempty"`
 	IsArchived                   bool                   `json:"is_archived"`
 	DeletedAt                    *time.Time             `json:"deleted_at,omitempty"`
 	ScheduledDeletionAt          *time.Time             `json:"scheduled_deletion_at,omitempty"`
@@ -62,6 +63,10 @@ func UserReadValueToResponse(customer values.ReadValue) Response {
 			MembershipPlanID:      &customer.MembershipInfo.MembershipPlanID,
 			MembershipPlanName:    &customer.MembershipInfo.MembershipPlanName,
 		}
+	}
+
+	if customer.AthleteInfo != nil && customer.AthleteInfo.PhotoURL != nil {
+		response.PhotoURL = customer.AthleteInfo.PhotoURL
 	}
 
 	return response


### PR DESCRIPTION
✨ Changes Made

  - Show program name and type instead of ID in audit log when deleting programs
  - Show team name instead of ID in audit log when deleting teams
  - Show location name and address instead of ID in audit log when deleting locations
  - Add photo_url field to customer response (GET /customers/id/{id} and GET /customers)

  ---
  🧠 Reason for Changes

  The staff activity logs (GET /staffs/logs) were displaying UUIDs when programs, teams, or locations were deleted, making it difficult to understand what was actually deleted. Now the logs show human-readable names (e.g., "Deleted program 'Basketball Training'" instead of "Deleted program with ID: f0e21457-...").

  Additionally, the customer endpoint was missing the photo_url field that was already available in the athlete profile data, so it has been added to the response for frontend use.

---




