### PR TITLE
[Bugfix] Fix courts for audit log

### DIFF
--- a/internal/domains/practice/services/service.go
+++ b/internal/domains/practice/services/service.go
@@ -59,7 +59,7 @@ func (s *Service) lookupNames(ctx context.Context, teamID, locationID uuid.UUID)
 
 	if locationID != uuid.Nil {
 		var name sql.NullString
-		_ = s.db.QueryRowContext(ctx, "SELECT name FROM facilities.locations WHERE id = $1", locationID).Scan(&name)
+		_ = s.db.QueryRowContext(ctx, "SELECT name FROM location.locations WHERE id = $1", locationID).Scan(&name)
 		if name.Valid {
 			locationName = name.String
 		}


### PR DESCRIPTION
✨ Changes Made

  - Fixed schema name in practice lookupNames function from facilities.locations to location.locations

  ---
  🧠 Reason for Changes

  The practice audit logs were showing "Unknown Location" instead of the actual location name. The lookupNames function was querying the wrong schema
   (facilities.locations) which doesn't exist - the correct schema is location.locations. The query was failing silently and falling back to the default "Unknown Location" string.

---