### PR TITLE
[feat/fix] Add Stripe checkout reconciliation system and security hardening

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -417,6 +417,10 @@ func RegisterCheckoutRoutes(container *di.Container) func(chi.Router) {
 		r.With(middlewares.JWTAuthMiddleware(true)).Post("/events/{id}", h.CheckoutEvent)
 		r.With(middlewares.JWTAuthMiddleware(true)).Get("/events/{id}/options", h.GetEventEnrollmentOptions)
 		r.With(middlewares.JWTAuthMiddleware(true)).Post("/events/{id}/enhanced", h.CheckoutEventEnhanced)
+
+		// Checkout verification endpoint - called by frontend after redirect from Stripe
+		// This ensures enrollment is complete even if webhooks fail
+		r.With(middlewares.JWTAuthMiddleware(true)).Post("/verify/{session_id}", h.VerifyCheckoutSession)
 	}
 }
 

--- a/cmd/server/server/main.go
+++ b/cmd/server/server/main.go
@@ -56,6 +56,7 @@ func main() {
 	scheduler.RegisterJob(jobs.NewSubsidyExpirationJob(diContainer))
 	scheduler.RegisterJob(jobs.NewAccountDeletionJob(diContainer))
 	scheduler.RegisterJob(jobs.NewReservationCleanupJob(diContainer))
+	scheduler.RegisterJob(jobs.NewCheckoutReconciliationJob(diContainer)) // Safety net for missed webhook payments
 	scheduler.Start()
 	defer scheduler.Stop()
 

--- a/config/configs.go
+++ b/config/configs.go
@@ -33,6 +33,7 @@ type config struct {
 	StripeWebhookSecret              string
 	ChatBotServiceUrl                string
 	FrontendBaseURL                  string // Frontend URL for email verification (supports Universal Links for mobile app)
+	Environment                      string // "production", "staging", or "development"
 }
 
 var Env = initConfig()
@@ -52,6 +53,12 @@ func initConfig() *config {
 
 	stripe.Key = stripeApiKey
 
+	// Get environment with fallback to "development"
+	environment := getEnv("ENVIRONMENT")
+	if environment == "" {
+		environment = "development"
+	}
+
 	return &config{
 		DbConnUrl:     getEnv("DATABASE_URL"),
 		HubSpotApiKey: getEnv("HUBSPOT_API_KEY"),
@@ -65,6 +72,7 @@ func initConfig() *config {
 		StripeWebhookSecret:              getEnv("STRIPE_WEBHOOK_SECRET"),
 		ChatBotServiceUrl:                getEnv("CHAT_BOT_SERVICE_URL"),
 		FrontendBaseURL:                  getEnv("FRONTEND_BASE_URL"),
+		Environment:                      environment,
 	}
 }
 

--- a/db/migrations/20251204120000_enhance_webhook_idempotency.sql
+++ b/db/migrations/20251204120000_enhance_webhook_idempotency.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Add error_message column to webhook_events for tracking failed processing
+ALTER TABLE payment.webhook_events
+ADD COLUMN IF NOT EXISTS error_message TEXT;
+
+-- Add index for status lookups (useful for retry/monitoring queries)
+CREATE INDEX IF NOT EXISTS idx_webhook_events_status ON payment.webhook_events(status);
+
+-- Add composite index for cleanup queries that check processed_at and status together
+CREATE INDEX IF NOT EXISTS idx_webhook_events_cleanup ON payment.webhook_events(processed_at, status)
+WHERE status = 'processing';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP INDEX IF EXISTS payment.idx_webhook_events_cleanup;
+DROP INDEX IF EXISTS payment.idx_webhook_events_status;
+
+ALTER TABLE payment.webhook_events
+DROP COLUMN IF EXISTS error_message;
+
+-- +goose StatementEnd

--- a/db/migrations/20251204120001_add_unique_active_membership_index.sql
+++ b/db/migrations/20251204120001_add_unique_active_membership_index.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Add unique partial index to prevent duplicate active memberships for the same plan
+-- This ensures a customer can only have ONE active membership per plan at a time
+-- The partial index only applies where status = 'active', so multiple canceled/expired records are fine
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_active_membership_per_plan
+ON users.customer_membership_plans (customer_id, membership_plan_id)
+WHERE status = 'active';
+
+-- Add index on stripe_subscription_id for faster lookups in webhook handlers
+CREATE INDEX IF NOT EXISTS idx_customer_membership_stripe_sub_id
+ON users.customer_membership_plans (stripe_subscription_id)
+WHERE stripe_subscription_id IS NOT NULL;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP INDEX IF EXISTS users.idx_customer_membership_stripe_sub_id;
+DROP INDEX IF EXISTS users.idx_unique_active_membership_per_plan;
+
+-- +goose StatementEnd

--- a/internal/domains/credit_package/handler/credit_package_handler.go
+++ b/internal/domains/credit_package/handler/credit_package_handler.go
@@ -87,10 +87,10 @@ func (h *CreditPackageHandler) CheckoutCreditPackage(w http.ResponseWriter, r *h
 		return
 	}
 
-	// Get success URL based on request origin
-	successURL := stripe.GetSuccessURLFromRequest(r)
+	// Get success and cancel URLs based on request origin
+	successURL, cancelURL := stripe.GetCheckoutURLs(r)
 
-	checkoutURL, err := h.Service.CheckoutCreditPackage(r.Context(), id, successURL)
+	checkoutURL, err := h.Service.CheckoutCreditPackage(r.Context(), id, successURL, cancelURL)
 	if err != nil {
 		responseHandlers.RespondWithError(w, err)
 		return

--- a/internal/domains/credit_package/service/credit_package_service.go
+++ b/internal/domains/credit_package/service/credit_package_service.go
@@ -99,7 +99,7 @@ func (s *CreditPackageService) GetPackageByID(ctx context.Context, id uuid.UUID)
 }
 
 // CheckoutCreditPackage creates a Stripe checkout session for purchasing a credit package
-func (s *CreditPackageService) CheckoutCreditPackage(ctx context.Context, packageID uuid.UUID, successURL string) (string, *errLib.CommonError) {
+func (s *CreditPackageService) CheckoutCreditPackage(ctx context.Context, packageID uuid.UUID, successURL string, cancelURL string) (string, *errLib.CommonError) {
 	// Get customer ID from context
 	customerID, err := contextUtils.GetUserID(ctx)
 	if err != nil {
@@ -129,7 +129,7 @@ func (s *CreditPackageService) CheckoutCreditPackage(ctx context.Context, packag
 	// Create Stripe checkout session for one-time payment
 	// Pass packageID in metadata so webhook can identify the purchase
 	packageIDStr := packageID.String()
-	checkoutURL, err := stripe.CreateOneTimePayment(ctx, pkg.StripePriceID, 1, &packageIDStr, nil, successURL, existingCustomerID)
+	checkoutURL, err := stripe.CreateOneTimePayment(ctx, pkg.StripePriceID, 1, &packageIDStr, nil, successURL, cancelURL, existingCustomerID)
 	if err != nil {
 		log.Printf("Failed to create Stripe checkout session: %v", err)
 		return "", err

--- a/internal/domains/enrollment/persistence/repository/stripe_membership_methods.go
+++ b/internal/domains/enrollment/persistence/repository/stripe_membership_methods.go
@@ -84,3 +84,22 @@ func (r *CustomerEnrollmentRepository) UpdateStripeSubscriptionStatusAndNextBill
 
 	return nil
 }
+
+// UpdateStripeSubscriptionStatusByIDAndNextBilling updates status and next billing date for a specific Stripe subscription
+func (r *CustomerEnrollmentRepository) UpdateStripeSubscriptionStatusByIDAndNextBilling(ctx context.Context, customerID uuid.UUID, stripeSubscriptionID string, status string, nextBillingDate time.Time) *errLib.CommonError {
+	query := `UPDATE users.customer_membership_plans
+			  SET status = $1, next_billing_date = $2, updated_at = CURRENT_TIMESTAMP
+			  WHERE customer_id = $3 AND stripe_subscription_id = $4 AND subscription_source = 'stripe'`
+
+	result, err := r.Db.ExecContext(ctx, query, status, sql.NullTime{Time: nextBillingDate, Valid: !nextBillingDate.IsZero()}, customerID, stripeSubscriptionID)
+	if err != nil {
+		log.Printf("Failed to update Stripe subscription status and next billing by ID: %v", err)
+		return errLib.New("Failed to update subscription", http.StatusInternalServerError)
+	}
+
+	rowsAffected, _ := result.RowsAffected()
+	log.Printf("Updated %d subscription(s) to status '%s' with next billing %s for customer %s (subscription: %s)",
+		rowsAffected, status, nextBillingDate.Format(time.RFC3339), customerID, stripeSubscriptionID)
+
+	return nil
+}

--- a/internal/domains/payment/handler/webhook.go
+++ b/internal/domains/payment/handler/webhook.go
@@ -94,17 +94,30 @@ func (h *WebhookHandlers) HandleStripeWebhook(w http.ResponseWriter, r *http.Req
 		webhookErr = h.Service.HandleSubscriptionUpdated(ctx, *event)
 	case "customer.subscription.deleted":
 		webhookErr = h.Service.HandleSubscriptionDeleted(ctx, *event)
+	case "customer.subscription.paused":
+		webhookErr = h.Service.HandleSubscriptionPaused(ctx, *event)
+	case "customer.subscription.resumed":
+		webhookErr = h.Service.HandleSubscriptionResumed(ctx, *event)
+	case "customer.updated":
+		webhookErr = h.Service.HandleCustomerUpdated(ctx, *event)
 	case "invoice.created":
 		// Apply subsidy credit BEFORE customer is charged
 		webhookErr = h.Service.HandleInvoiceCreated(ctx, *event)
 	case "invoice.finalized":
 		// Apply subsidy credit at finalization (after subscription linked, before payment)
 		webhookErr = h.Service.HandleInvoiceFinalized(ctx, *event)
+	case "invoice.upcoming":
+		// Sent ~3 days before renewal - useful for reminder emails
+		webhookErr = h.Service.HandleInvoiceUpcoming(ctx, *event)
 	case "invoice.payment_succeeded":
 		// Records subsidy usage after successful payment
 		webhookErr = h.Service.HandleInvoicePaymentSucceededWithSubsidy(ctx, *event)
 	case "invoice.payment_failed":
 		webhookErr = h.Service.HandleInvoicePaymentFailed(ctx, *event)
+	case "payment_method.attached":
+		webhookErr = h.Service.HandlePaymentMethodAttached(ctx, *event)
+	case "payment_method.detached":
+		webhookErr = h.Service.HandlePaymentMethodDetached(ctx, *event)
 	default:
 		log.Printf("[STRIPE] Unhandled webhook event type: %s", event.Type)
 		w.WriteHeader(http.StatusOK)

--- a/internal/domains/payment/services/checkout.go
+++ b/internal/domains/payment/services/checkout.go
@@ -76,7 +76,7 @@ func (s *Service) queueFailedRefund(ctx context.Context, customerID, eventID uui
 	}
 }
 
-func (s *Service) CheckoutMembershipPlan(ctx context.Context, membershipPlanID uuid.UUID, discountCode *string, successURL string) (string, *errLib.CommonError) {
+func (s *Service) CheckoutMembershipPlan(ctx context.Context, membershipPlanID uuid.UUID, discountCode *string, successURL string, cancelURL string) (string, *errLib.CommonError) {
 	// Get customer ID from context
 	customerID, ctxErr := contextUtils.GetUserID(ctx)
 	if ctxErr != nil {
@@ -154,17 +154,17 @@ func (s *Service) CheckoutMembershipPlan(ctx context.Context, membershipPlanID u
 	// Check if membership has any joining fee
 	if requirements.StripeJoiningFeeID != "" {
 		// Use recurring joining fee (annual/monthly) - existing function handles this
-		return stripe.CreateSubscriptionWithMetadata(ctx, requirements.StripePriceID, requirements.StripeJoiningFeeID, stripeCouponID, metadata, successURL, existingCustomerID)
+		return stripe.CreateSubscriptionWithMetadata(ctx, requirements.StripePriceID, requirements.StripeJoiningFeeID, stripeCouponID, metadata, successURL, cancelURL, existingCustomerID)
 	} else if requirements.JoiningFee > 0 {
 		// Use one-time setup fee
-		return stripe.CreateSubscriptionWithSetupFeeAndMetadata(ctx, requirements.StripePriceID, requirements.JoiningFee, metadata, successURL, existingCustomerID)
+		return stripe.CreateSubscriptionWithSetupFeeAndMetadata(ctx, requirements.StripePriceID, requirements.JoiningFee, metadata, successURL, cancelURL, existingCustomerID)
 	} else {
 		// No joining fee - just regular subscription
-		return stripe.CreateSubscriptionWithMetadata(ctx, requirements.StripePriceID, "", stripeCouponID, metadata, successURL, existingCustomerID)
+		return stripe.CreateSubscriptionWithMetadata(ctx, requirements.StripePriceID, "", stripeCouponID, metadata, successURL, cancelURL, existingCustomerID)
 	}
 }
 
-func (s *Service) CheckoutProgram(ctx context.Context, programID uuid.UUID, discountCode *string, successURL string) (string, *errLib.CommonError) {
+func (s *Service) CheckoutProgram(ctx context.Context, programID uuid.UUID, discountCode *string, successURL string, cancelURL string) (string, *errLib.CommonError) {
 	customerID, ctxErr := contextUtils.GetUserID(ctx)
 	if ctxErr != nil {
 		return "", ctxErr
@@ -212,10 +212,10 @@ func (s *Service) CheckoutProgram(ctx context.Context, programID uuid.UUID, disc
 	existingCustomerID := s.getExistingStripeCustomerID(ctx, customerID)
 
 	programIDStr := programID.String()
-	return stripe.CreateOneTimePayment(ctx, priceID, 1, &programIDStr, stripeCouponID, successURL, existingCustomerID)
+	return stripe.CreateOneTimePayment(ctx, priceID, 1, &programIDStr, stripeCouponID, successURL, cancelURL, existingCustomerID)
 }
 
-func (s *Service) CheckoutEvent(ctx context.Context, eventID uuid.UUID, discountCode *string, successURL string) (string, *errLib.CommonError) {
+func (s *Service) CheckoutEvent(ctx context.Context, eventID uuid.UUID, discountCode *string, successURL string, cancelURL string) (string, *errLib.CommonError) {
 	customerID, ctxErr := contextUtils.GetUserID(ctx)
 	if ctxErr != nil {
 		return "", ctxErr
@@ -266,7 +266,7 @@ func (s *Service) CheckoutEvent(ctx context.Context, eventID uuid.UUID, discount
 	existingCustomerID := s.getExistingStripeCustomerID(ctx, customerID)
 
 	eventIDStr := eventID.String()
-	return stripe.CreateOneTimePayment(ctx, priceID, 1, &eventIDStr, stripeCouponID, successURL, existingCustomerID)
+	return stripe.CreateOneTimePayment(ctx, priceID, 1, &eventIDStr, stripeCouponID, successURL, cancelURL, existingCustomerID)
 }
 
 // CheckEventEnrollmentOptions returns available enrollment options for a customer and event
@@ -405,7 +405,7 @@ func (s *Service) CheckoutEventWithCredits(ctx context.Context, eventID uuid.UUI
 }
 
 // Enhanced CheckoutEvent with membership validation
-func (s *Service) CheckoutEventEnhanced(ctx context.Context, eventID uuid.UUID, discountCode *string, successURL string) (string, *errLib.CommonError) {
+func (s *Service) CheckoutEventEnhanced(ctx context.Context, eventID uuid.UUID, discountCode *string, successURL string, cancelURL string) (string, *errLib.CommonError) {
 	customerID, ctxErr := contextUtils.GetUserID(ctx)
 	if ctxErr != nil {
 		return "", ctxErr
@@ -466,5 +466,5 @@ func (s *Service) CheckoutEventEnhanced(ctx context.Context, eventID uuid.UUID, 
 	existingCustomerID := s.getExistingStripeCustomerID(ctx, customerID)
 
 	eventIDStr := eventID.String()
-	return stripe.CreateOneTimePayment(ctx, *options.StripePriceID, 1, &eventIDStr, stripeCouponID, successURL, existingCustomerID)
+	return stripe.CreateOneTimePayment(ctx, *options.StripePriceID, 1, &eventIDStr, stripeCouponID, successURL, cancelURL, existingCustomerID)
 }

--- a/internal/domains/payment/services/checkout_verification.go
+++ b/internal/domains/payment/services/checkout_verification.go
@@ -1,0 +1,403 @@
+package payment
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"net/http"
+	"time"
+
+	"api/internal/di"
+	creditPackageRepo "api/internal/domains/credit_package/persistence/repository"
+	enrollment "api/internal/domains/enrollment/service"
+	repository "api/internal/domains/payment/persistence/repositories"
+	"api/internal/domains/payment/services/stripe"
+	userServices "api/internal/domains/user/services"
+	errLib "api/internal/libs/errors"
+	"api/internal/libs/logger"
+
+	"github.com/google/uuid"
+	stripeLib "github.com/stripe/stripe-go/v81"
+)
+
+// CheckoutVerificationService handles verification of checkout sessions
+// This provides a safety net when webhooks fail or are delayed
+type CheckoutVerificationService struct {
+	PostCheckoutRepository *repository.PostCheckoutRepository
+	EnrollmentService      *enrollment.CustomerEnrollmentService
+	CreditPackageRepo      *creditPackageRepo.CreditPackageRepository
+	CustomerCreditService  *userServices.CustomerCreditService
+	db                     *sql.DB
+	logger                 *logger.StructuredLogger
+}
+
+// NewCheckoutVerificationService creates a new checkout verification service
+func NewCheckoutVerificationService(container *di.Container) *CheckoutVerificationService {
+	return &CheckoutVerificationService{
+		PostCheckoutRepository: repository.NewPostCheckoutRepository(container),
+		EnrollmentService:      enrollment.NewCustomerEnrollmentService(container),
+		CreditPackageRepo:      creditPackageRepo.NewCreditPackageRepository(container),
+		CustomerCreditService:  userServices.NewCustomerCreditService(container),
+		db:                     container.DB,
+		logger:                 logger.WithComponent("checkout-verification"),
+	}
+}
+
+// VerificationResult contains the result of a checkout verification
+type VerificationResult struct {
+	SessionID        string `json:"session_id"`
+	PaymentStatus    string `json:"payment_status"`
+	EnrollmentStatus string `json:"enrollment_status"`
+	WasReconciled    bool   `json:"was_reconciled"`
+	Message          string `json:"message"`
+}
+
+// VerifyCheckoutSession verifies a checkout session and ensures the customer is enrolled
+// This is called by the frontend after redirect from Stripe checkout
+func (s *CheckoutVerificationService) VerifyCheckoutSession(ctx context.Context, sessionID string, userID uuid.UUID) (*VerificationResult, *errLib.CommonError) {
+	s.logger.WithFields(map[string]interface{}{
+		"session_id": sessionID,
+		"user_id":    userID,
+	}).Info("Verifying checkout session")
+
+	// 1. Retrieve the checkout session from Stripe
+	checkoutSession, err := stripe.GetCheckoutSession(sessionID)
+	if err != nil {
+		s.logger.Error("Failed to retrieve checkout session from Stripe", err)
+		return nil, err
+	}
+
+	// 2. Validate that this session belongs to the requesting user
+	sessionUserIDStr := checkoutSession.Metadata["userID"]
+	if sessionUserIDStr == "" {
+		s.logger.Error("Session has no userID in metadata", nil)
+		return nil, errLib.New("Invalid checkout session", http.StatusBadRequest)
+	}
+
+	sessionUserID, parseErr := uuid.Parse(sessionUserIDStr)
+	if parseErr != nil || sessionUserID != userID {
+		s.logger.WithFields(map[string]interface{}{
+			"session_user_id":  sessionUserIDStr,
+			"request_user_id":  userID,
+		}).Error("User ID mismatch - potential security issue", nil)
+		return nil, errLib.New("Access denied", http.StatusForbidden)
+	}
+
+	// 3. Check payment status
+	result := &VerificationResult{
+		SessionID:     sessionID,
+		PaymentStatus: string(checkoutSession.PaymentStatus),
+	}
+
+	if checkoutSession.PaymentStatus != stripeLib.CheckoutSessionPaymentStatusPaid {
+		result.EnrollmentStatus = "payment_incomplete"
+		result.Message = "Payment has not been completed"
+		return result, nil
+	}
+
+	// 4. Check if customer is already enrolled (webhook already processed)
+	isEnrolled, enrollErr := s.checkIfAlreadyEnrolled(ctx, checkoutSession, userID)
+	if enrollErr != nil {
+		s.logger.Error("Failed to check enrollment status", enrollErr)
+		return nil, enrollErr
+	}
+
+	if isEnrolled {
+		result.EnrollmentStatus = "enrolled"
+		result.WasReconciled = false
+		result.Message = "Customer is already enrolled"
+		return result, nil
+	}
+
+	// 5. Payment is complete but customer not enrolled - reconcile now
+	s.logger.WithFields(map[string]interface{}{
+		"session_id": sessionID,
+		"user_id":    userID,
+	}).Warn("Payment complete but enrollment missing - reconciling now")
+
+	reconcileErr := s.reconcileCheckout(ctx, checkoutSession, userID)
+	if reconcileErr != nil {
+		s.logger.Error("Failed to reconcile checkout", reconcileErr)
+		result.EnrollmentStatus = "reconciliation_failed"
+		result.Message = "Payment received but enrollment failed - please contact support"
+		// Alert for manual intervention
+		s.alertReconciliationFailure(sessionID, userID, reconcileErr)
+		return result, nil
+	}
+
+	result.EnrollmentStatus = "enrolled"
+	result.WasReconciled = true
+	result.Message = "Payment verified and enrollment completed"
+
+	// Log successful reconciliation for audit
+	s.logger.WithFields(map[string]interface{}{
+		"session_id": sessionID,
+		"user_id":    userID,
+	}).Info("Successfully reconciled missed webhook - customer enrolled")
+
+	return result, nil
+}
+
+// checkIfAlreadyEnrolled checks if the customer is already enrolled based on checkout type
+func (s *CheckoutVerificationService) checkIfAlreadyEnrolled(ctx context.Context, session *stripeLib.CheckoutSession, userID uuid.UUID) (bool, *errLib.CommonError) {
+	// Check membership plan enrollment
+	if membershipPlanIDStr := session.Metadata["membershipPlanID"]; membershipPlanIDStr != "" {
+		planID, err := uuid.Parse(membershipPlanIDStr)
+		if err != nil {
+			return false, errLib.New("Invalid membership plan ID in session", http.StatusBadRequest)
+		}
+		return s.checkMembershipEnrollment(ctx, userID, planID)
+	}
+
+	// Check credit package purchase by looking at price IDs
+	if session.LineItems != nil && len(session.LineItems.Data) > 0 {
+		for _, item := range session.LineItems.Data {
+			if item.Price != nil {
+				// Check if this is a credit package
+				pkg, _ := s.CreditPackageRepo.GetByStripePriceID(ctx, item.Price.ID)
+				if pkg != nil {
+					// For credit packages, check if customer already has this package active
+					return s.checkCreditPackageActive(ctx, userID, pkg.ID)
+				}
+			}
+		}
+	}
+
+	// For programs/events, check by session metadata
+	// Programs and events use reservation status, not a separate enrollment table
+	return false, nil
+}
+
+// checkMembershipEnrollment checks if customer has an active membership for the plan
+func (s *CheckoutVerificationService) checkMembershipEnrollment(ctx context.Context, customerID, planID uuid.UUID) (bool, *errLib.CommonError) {
+	query := `SELECT EXISTS(
+		SELECT 1 FROM users.customer_membership_plans
+		WHERE customer_id = $1 AND membership_plan_id = $2 AND status = 'active'
+	)`
+
+	var exists bool
+	err := s.db.QueryRowContext(ctx, query, customerID, planID).Scan(&exists)
+	if err != nil {
+		log.Printf("Error checking membership enrollment: %v", err)
+		return false, errLib.New("Failed to check enrollment status", http.StatusInternalServerError)
+	}
+
+	return exists, nil
+}
+
+// checkCreditPackageActive checks if customer has an active credit package
+func (s *CheckoutVerificationService) checkCreditPackageActive(ctx context.Context, customerID, packageID uuid.UUID) (bool, *errLib.CommonError) {
+	query := `SELECT EXISTS(
+		SELECT 1 FROM users.customer_credit_packages
+		WHERE customer_id = $1 AND credit_package_id = $2
+	)`
+
+	var exists bool
+	err := s.db.QueryRowContext(ctx, query, customerID, packageID).Scan(&exists)
+	if err != nil {
+		log.Printf("Error checking credit package: %v", err)
+		return false, errLib.New("Failed to check credit package status", http.StatusInternalServerError)
+	}
+
+	return exists, nil
+}
+
+// reconcileCheckout processes a checkout that was missed by webhooks
+func (s *CheckoutVerificationService) reconcileCheckout(ctx context.Context, session *stripeLib.CheckoutSession, userID uuid.UUID) *errLib.CommonError {
+	eventCreatedAt := time.Unix(session.Created, 0)
+
+	// Handle subscription checkout (membership)
+	if session.Mode == stripeLib.CheckoutSessionModeSubscription {
+		return s.reconcileMembershipCheckout(ctx, session, userID, eventCreatedAt)
+	}
+
+	// Handle one-time payment (credit package, program, event)
+	if session.Mode == stripeLib.CheckoutSessionModePayment {
+		return s.reconcileOneTimeCheckout(ctx, session, userID, eventCreatedAt)
+	}
+
+	return errLib.New("Unknown checkout mode", http.StatusBadRequest)
+}
+
+// reconcileMembershipCheckout reconciles a missed membership subscription checkout
+func (s *CheckoutVerificationService) reconcileMembershipCheckout(ctx context.Context, session *stripeLib.CheckoutSession, userID uuid.UUID, eventCreatedAt time.Time) *errLib.CommonError {
+	membershipPlanIDStr := session.Metadata["membershipPlanID"]
+	if membershipPlanIDStr == "" {
+		return errLib.New("Missing membership plan ID in session metadata", http.StatusBadRequest)
+	}
+
+	planID, err := uuid.Parse(membershipPlanIDStr)
+	if err != nil {
+		return errLib.New("Invalid membership plan ID", http.StatusBadRequest)
+	}
+
+	// Store Stripe customer ID if not already stored
+	if session.Customer != nil && session.Customer.ID != "" {
+		s.storeStripeCustomerID(userID, session.Customer.ID)
+	}
+
+	// Get amt_periods from membership plan to calculate renewal date
+	amtPeriods, amtErr := s.PostCheckoutRepository.GetMembershipPlanAmtPeriods(ctx, planID)
+	if amtErr != nil {
+		log.Printf("[RECONCILE] Warning: Could not get amt_periods for plan %s: %v", planID, amtErr)
+	}
+
+	subscriptionID := ""
+	var cancelAtDateTime time.Time
+	var nextBillingDate time.Time
+
+	// Get subscription details from Stripe for proper dates
+	if session.Subscription != nil {
+		subscriptionID = session.Subscription.ID
+
+		// Fetch full subscription details from Stripe
+		sub, subErr := stripe.GetSubscriptionDetails(subscriptionID)
+		if subErr != nil {
+			log.Printf("[RECONCILE] Warning: Could not fetch subscription %s from Stripe: %v", subscriptionID, subErr)
+		} else {
+			// Get next billing date from current period end
+			if sub.CurrentPeriodEnd > 0 {
+				nextBillingDate = time.Unix(sub.CurrentPeriodEnd, 0)
+			}
+
+			// If plan has amt_periods, calculate the renewal/cancel date
+			// This replicates the webhook's calculateCancelAt logic
+			if amtPeriods != nil && *amtPeriods > 0 && len(sub.Items.Data) > 0 {
+				item := sub.Items.Data[0]
+				if item.Price != nil && item.Price.Recurring != nil {
+					interval := item.Price.Recurring.Interval
+					intervalCount := int(item.Price.Recurring.IntervalCount)
+					periods := int(*amtPeriods)
+
+					log.Printf("[RECONCILE] Calculating cancel date: interval=%s, intervalCount=%d, periods=%d", interval, intervalCount, periods)
+
+					var cancelTime time.Time
+					switch interval {
+					case stripeLib.PriceRecurringIntervalMonth:
+						cancelTime = eventCreatedAt.AddDate(0, intervalCount*periods, 0)
+					case stripeLib.PriceRecurringIntervalYear:
+						cancelTime = eventCreatedAt.AddDate(intervalCount*periods, 0, 0)
+					case stripeLib.PriceRecurringIntervalWeek:
+						cancelTime = eventCreatedAt.AddDate(0, 0, 7*intervalCount*periods)
+					case stripeLib.PriceRecurringIntervalDay:
+						cancelTime = eventCreatedAt.AddDate(0, 0, intervalCount*periods)
+					default:
+						log.Printf("[RECONCILE] Unsupported billing interval: %s", interval)
+					}
+
+					if !cancelTime.IsZero() {
+						cancelAtDateTime = cancelTime
+						log.Printf("[RECONCILE] Calculated cancel date: %v", cancelAtDateTime)
+
+						// Update the Stripe subscription with the cancel date
+						if updateErr := stripe.UpdateSubscriptionCancelAt(subscriptionID, cancelTime.Unix()); updateErr != nil {
+							log.Printf("[RECONCILE] Warning: Failed to update subscription cancel date in Stripe: %v", updateErr)
+						} else {
+							log.Printf("[RECONCILE] Updated Stripe subscription %s with cancel_at: %v", subscriptionID, cancelTime)
+						}
+					}
+				}
+			} else if sub.CancelAt > 0 {
+				// Fallback: use existing cancel date from Stripe if already set
+				cancelAtDateTime = time.Unix(sub.CancelAt, 0)
+			}
+
+			log.Printf("[RECONCILE] Got subscription dates - Next billing: %v, Cancel at: %v", nextBillingDate, cancelAtDateTime)
+		}
+	}
+
+	// Enroll customer in membership plan
+	log.Printf("[RECONCILE] Enrolling customer %s in membership plan %s (subscription: %s)", userID, planID, subscriptionID)
+	if enrollErr := s.EnrollmentService.EnrollCustomerInMembershipPlan(ctx, userID, planID, cancelAtDateTime, nextBillingDate, eventCreatedAt, subscriptionID); enrollErr != nil {
+		return enrollErr
+	}
+
+	log.Printf("[RECONCILE] Successfully enrolled customer %s in membership plan %s", userID, planID)
+	return nil
+}
+
+// reconcileOneTimeCheckout reconciles a missed one-time payment checkout
+func (s *CheckoutVerificationService) reconcileOneTimeCheckout(ctx context.Context, session *stripeLib.CheckoutSession, userID uuid.UUID, eventCreatedAt time.Time) *errLib.CommonError {
+	if session.LineItems == nil || len(session.LineItems.Data) == 0 {
+		return errLib.New("No line items in checkout session", http.StatusBadRequest)
+	}
+
+	for _, item := range session.LineItems.Data {
+		if item.Price == nil {
+			continue
+		}
+
+		priceID := item.Price.ID
+
+		// Check if this is a credit package
+		pkg, _ := s.CreditPackageRepo.GetByStripePriceID(ctx, priceID)
+		if pkg != nil {
+			// Process credit package purchase
+			log.Printf("[RECONCILE] Adding %d credits to customer %s from package %s", pkg.CreditAllocation, userID, pkg.ID)
+			if err := s.CustomerCreditService.AddCredits(ctx, userID, pkg.CreditAllocation, "Credit package purchase (reconciled)"); err != nil {
+				return errLib.New("Failed to add credits: "+err.Error(), http.StatusInternalServerError)
+			}
+
+			// Set active credit package
+			if err := s.CreditPackageRepo.SetCustomerActivePackage(ctx, userID, pkg.ID, pkg.WeeklyCreditLimit); err != nil {
+				return errLib.New("Failed to set active package: "+err.Error(), http.StatusInternalServerError)
+			}
+
+			log.Printf("[RECONCILE] Successfully processed credit package %s for customer %s", pkg.ID, userID)
+			return nil
+		}
+
+		// Check if this is a program enrollment
+		programID, progErr := s.PostCheckoutRepository.GetProgramIdByStripePriceId(ctx, priceID)
+		if progErr == nil && programID != uuid.Nil {
+			log.Printf("[RECONCILE] Updating program reservation for customer %s, program %s", userID, programID)
+			if err := s.EnrollmentService.UpdateReservationStatusInProgram(ctx, programID, userID, "paid"); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// Check if this is an event enrollment
+		eventID, evtErr := s.PostCheckoutRepository.GetEventIdByStripePriceId(ctx, priceID)
+		if evtErr == nil && eventID != uuid.Nil {
+			log.Printf("[RECONCILE] Updating event reservation for customer %s, event %s", userID, eventID)
+			if err := s.EnrollmentService.UpdateReservationStatusInEvent(ctx, eventID, userID, "paid"); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+
+	return errLib.New("Could not identify checkout product type", http.StatusBadRequest)
+}
+
+// storeStripeCustomerID stores the Stripe customer ID for the user
+func (s *CheckoutVerificationService) storeStripeCustomerID(userID uuid.UUID, stripeCustomerID string) {
+	query := `UPDATE users.users SET stripe_customer_id = $1 WHERE id = $2 AND (stripe_customer_id IS NULL OR stripe_customer_id = '')`
+	_, err := s.db.Exec(query, stripeCustomerID, userID)
+	if err != nil {
+		log.Printf("[RECONCILE] Failed to store Stripe customer ID: %v", err)
+	}
+}
+
+// alertReconciliationFailure sends an alert when reconciliation fails
+func (s *CheckoutVerificationService) alertReconciliationFailure(sessionID string, userID uuid.UUID, err *errLib.CommonError) {
+	// Log the error
+	s.logger.WithFields(map[string]interface{}{
+		"session_id":  sessionID,
+		"user_id":     userID,
+		"error":       err.Error(),
+		"alert_type":  "reconciliation_failure",
+		"severity":    "critical",
+	}).Error("CRITICAL: Checkout reconciliation failed - manual intervention required", err)
+
+	// Send Slack alert
+	logger.SendReconciliationAlert(logger.ReconciliationAlertDetails{
+		SessionID:    sessionID,
+		CustomerID:   userID.String(),
+		AlertType:    "RECONCILIATION_FAILURE",
+		ErrorMessage: err.Error(),
+		WasFixed:     false,
+		Product:      "unknown",
+	})
+}

--- a/internal/domains/payment/services/stripe/stripe_test.go
+++ b/internal/domains/payment/services/stripe/stripe_test.go
@@ -60,7 +60,7 @@ func TestCreateOneTimePayment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			paymentLink, err := payment.CreateOneTimePayment(ctx, tt.priceID, tt.quantity, nil, nil, "https://www.rise-basketball.com/success", nil)
+			paymentLink, err := payment.CreateOneTimePayment(ctx, tt.priceID, tt.quantity, nil, nil, "https://www.rise-basketball.com/success", "https://www.rise-basketball.com/cancel", nil)
 
 			if tt.wantErr {
 				if err == nil {
@@ -136,6 +136,7 @@ func TestCreateSubscription(t *testing.T) {
 				tt.joiningFeesID,
 				nil,
 				"https://www.rise-basketball.com/success",
+				"https://www.rise-basketball.com/cancel",
 				nil,
 			)
 
@@ -212,6 +213,7 @@ func TestCreateSubscription_Context(t *testing.T) {
 				"price_1RA7MAAB1pU7EbknpkvwLmyp",
 				nil,
 				"https://www.rise-basketball.com/success",
+				"https://www.rise-basketball.com/cancel",
 				nil,
 			)
 

--- a/internal/domains/payment/services/stripe/url_helpers.go
+++ b/internal/domains/payment/services/stripe/url_helpers.go
@@ -7,6 +7,25 @@ import (
 
 // GetSuccessURLFromRequest determines the appropriate success URL based on the request origin
 func GetSuccessURLFromRequest(r *http.Request) string {
+	origin := getOriginFromRequest(r)
+	return getSuccessURLForOrigin(origin)
+}
+
+// GetCancelURLFromRequest determines the appropriate cancel URL based on the request origin
+// This URL is where users are redirected when they abort the checkout process
+func GetCancelURLFromRequest(r *http.Request) string {
+	origin := getOriginFromRequest(r)
+	return getCancelURLForOrigin(origin)
+}
+
+// GetCheckoutURLs returns both success and cancel URLs for a checkout session
+func GetCheckoutURLs(r *http.Request) (successURL, cancelURL string) {
+	origin := getOriginFromRequest(r)
+	return getSuccessURLForOrigin(origin), getCancelURLForOrigin(origin)
+}
+
+// getOriginFromRequest extracts the origin from request headers
+func getOriginFromRequest(r *http.Request) string {
 	// Try to get origin from the Origin header first
 	origin := r.Header.Get("Origin")
 
@@ -29,10 +48,12 @@ func GetSuccessURLFromRequest(r *http.Request) string {
 		}
 	}
 
-	// Map known domains to their success URLs
 	// Normalize origin by removing trailing slash
-	origin = strings.TrimSuffix(origin, "/")
+	return strings.TrimSuffix(origin, "/")
+}
 
+// getSuccessURLForOrigin maps origin to success URL
+func getSuccessURLForOrigin(origin string) string {
 	switch {
 	case strings.Contains(origin, "risesportscomplex.com"):
 		return "https://www.risesportscomplex.com/success"
@@ -43,5 +64,21 @@ func GetSuccessURLFromRequest(r *http.Request) string {
 	default:
 		// Default to rise-basketball.com if origin is unknown or localhost
 		return "https://www.rise-basketball.com/success"
+	}
+}
+
+// getCancelURLForOrigin maps origin to cancel URL
+// Users are redirected here when they click "back" or close the Stripe checkout
+func getCancelURLForOrigin(origin string) string {
+	switch {
+	case strings.Contains(origin, "risesportscomplex.com"):
+		return "https://www.risesportscomplex.com/checkout/canceled"
+	case strings.Contains(origin, "rise-basketball.com"):
+		return "https://www.rise-basketball.com/checkout/canceled"
+	case strings.Contains(origin, "riseup-hoops.com"):
+		return "https://www.riseup-hoops.com/checkout/canceled"
+	default:
+		// Default to rise-basketball.com if origin is unknown or localhost
+		return "https://www.rise-basketball.com/checkout/canceled"
 	}
 }

--- a/internal/jobs/checkout_reconciliation.go
+++ b/internal/jobs/checkout_reconciliation.go
@@ -1,0 +1,447 @@
+package jobs
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"time"
+
+	"api/internal/di"
+	creditPackageRepo "api/internal/domains/credit_package/persistence/repository"
+	enrollment "api/internal/domains/enrollment/service"
+	postCheckoutRepo "api/internal/domains/payment/persistence/repositories"
+	stripeService "api/internal/domains/payment/services/stripe"
+	userServices "api/internal/domains/user/services"
+	"api/internal/libs/logger"
+
+	"github.com/google/uuid"
+	"github.com/stripe/stripe-go/v81"
+	"github.com/stripe/stripe-go/v81/subscription"
+)
+
+// CheckoutReconciliationJob catches paid checkout sessions that weren't processed by webhooks
+// This is the safety net for when webhooks fail
+type CheckoutReconciliationJob struct {
+	db                     *sql.DB
+	postCheckoutRepository *postCheckoutRepo.PostCheckoutRepository
+	enrollmentService      *enrollment.CustomerEnrollmentService
+	creditPackageRepo      *creditPackageRepo.CreditPackageRepository
+	customerCreditService  *userServices.CustomerCreditService
+	logger                 *logger.StructuredLogger
+}
+
+// NewCheckoutReconciliationJob creates a new checkout reconciliation job
+func NewCheckoutReconciliationJob(container *di.Container) *CheckoutReconciliationJob {
+	return &CheckoutReconciliationJob{
+		db:                     container.DB,
+		postCheckoutRepository: postCheckoutRepo.NewPostCheckoutRepository(container),
+		enrollmentService:      enrollment.NewCustomerEnrollmentService(container),
+		creditPackageRepo:      creditPackageRepo.NewCreditPackageRepository(container),
+		customerCreditService:  userServices.NewCustomerCreditService(container),
+		logger:                 logger.WithComponent("checkout-reconciliation"),
+	}
+}
+
+// Name returns the job name
+func (j *CheckoutReconciliationJob) Name() string {
+	return "CheckoutReconciliation"
+}
+
+// Interval returns how often this job runs (every 30 minutes)
+func (j *CheckoutReconciliationJob) Interval() time.Duration {
+	return 30 * time.Minute
+}
+
+// Run executes the reconciliation logic
+func (j *CheckoutReconciliationJob) Run(ctx context.Context) error {
+	j.logger.Info("Starting checkout reconciliation job")
+
+	// Look back 24 hours for missed checkouts
+	sinceTime := time.Now().Add(-24 * time.Hour)
+
+	// Get completed checkout sessions from Stripe
+	sessions, err := stripeService.ListRecentCheckoutSessions(sinceTime, 100)
+	if err != nil {
+		j.logger.Error("Failed to list checkout sessions from Stripe", err)
+		return err
+	}
+
+	var (
+		checked       int
+		reconciled    int
+		skipped       int
+		errorCount    int
+		failedSessions []string // Track failed session IDs for summary alert
+	)
+
+	for _, session := range sessions {
+		checked++
+
+		// Only process completed sessions with paid status
+		if session.PaymentStatus != stripe.CheckoutSessionPaymentStatusPaid {
+			skipped++
+			continue
+		}
+
+		// Get user ID from metadata
+		userIDStr := session.Metadata["userID"]
+		if userIDStr == "" {
+			j.logger.WithFields(map[string]interface{}{
+				"session_id": session.ID,
+			}).Warn("Session has no userID metadata, skipping")
+			skipped++
+			continue
+		}
+
+		userID, parseErr := uuid.Parse(userIDStr)
+		if parseErr != nil {
+			j.logger.WithFields(map[string]interface{}{
+				"session_id": session.ID,
+				"user_id":    userIDStr,
+			}).Warn("Invalid userID in session metadata")
+			skipped++
+			continue
+		}
+
+		// Check if this checkout was already processed
+		processed, checkErr := j.wasCheckoutProcessed(ctx, session, userID)
+		if checkErr != nil {
+			j.logger.WithFields(map[string]interface{}{
+				"session_id": session.ID,
+				"user_id":    userID,
+			}).Warn("Failed to check if checkout was processed")
+			errorCount++
+			continue
+		}
+
+		if processed {
+			// Already processed, skip
+			skipped++
+			continue
+		}
+
+		// This checkout was missed - reconcile it now
+		j.logger.WithFields(map[string]interface{}{
+			"session_id": session.ID,
+			"user_id":    userID,
+			"mode":       session.Mode,
+		}).Warn("MISSED CHECKOUT DETECTED - reconciling now")
+
+		reconcileErr := j.reconcileCheckout(ctx, session, userID)
+		if reconcileErr != nil {
+			j.logger.WithFields(map[string]interface{}{
+				"session_id": session.ID,
+				"user_id":    userID,
+				"error":      reconcileErr.Error(),
+			}).Warn("Failed to reconcile checkout - will retry next run")
+			errorCount++
+			failedSessions = append(failedSessions, session.ID)
+		} else {
+			j.logger.WithFields(map[string]interface{}{
+				"session_id": session.ID,
+				"user_id":    userID,
+				"product":    j.getProductType(session),
+			}).Info("Successfully reconciled missed checkout")
+			reconciled++
+		}
+	}
+
+	j.logger.WithFields(map[string]interface{}{
+		"checked":    checked,
+		"reconciled": reconciled,
+		"skipped":    skipped,
+		"errors":     errorCount,
+	}).Info("Checkout reconciliation job completed")
+
+	// Send ONE summary Slack alert only if there were reconciled checkouts or persistent failures
+	if reconciled > 0 || errorCount > 0 {
+		j.sendSummaryAlert(reconciled, errorCount, failedSessions)
+	}
+
+	return nil
+}
+
+// wasCheckoutProcessed checks if a checkout session was already processed
+func (j *CheckoutReconciliationJob) wasCheckoutProcessed(ctx context.Context, session *stripe.CheckoutSession, userID uuid.UUID) (bool, error) {
+	// For subscriptions, check if user has a membership with this subscription ID
+	if session.Mode == stripe.CheckoutSessionModeSubscription {
+		membershipPlanIDStr := session.Metadata["membershipPlanID"]
+		if membershipPlanIDStr == "" {
+			// Can't determine, assume not processed
+			return false, nil
+		}
+
+		planID, err := uuid.Parse(membershipPlanIDStr)
+		if err != nil {
+			return false, nil
+		}
+
+		return j.hasMembershipForPlan(ctx, userID, planID)
+	}
+
+	// For one-time payments, check based on the product type
+	if session.Mode == stripe.CheckoutSessionModePayment {
+		// Check line items to determine what was purchased
+		if session.LineItems == nil || len(session.LineItems.Data) == 0 {
+			return false, nil
+		}
+
+		for _, item := range session.LineItems.Data {
+			if item.Price == nil {
+				continue
+			}
+
+			// Check if this is a credit package
+			pkg, _ := j.creditPackageRepo.GetByStripePriceID(ctx, item.Price.ID)
+			if pkg != nil {
+				return j.hasCreditPackageActive(ctx, userID, pkg.ID)
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// hasMembershipForPlan checks if user has an active membership for a plan
+func (j *CheckoutReconciliationJob) hasMembershipForPlan(ctx context.Context, userID, planID uuid.UUID) (bool, error) {
+	query := `SELECT EXISTS(
+		SELECT 1 FROM users.customer_membership_plans
+		WHERE customer_id = $1 AND membership_plan_id = $2 AND status = 'active'
+	)`
+
+	var exists bool
+	err := j.db.QueryRowContext(ctx, query, userID, planID).Scan(&exists)
+	return exists, err
+}
+
+// hasCreditPackageActive checks if user has an active credit package
+func (j *CheckoutReconciliationJob) hasCreditPackageActive(ctx context.Context, userID, packageID uuid.UUID) (bool, error) {
+	query := `SELECT EXISTS(
+		SELECT 1 FROM users.customer_credit_packages
+		WHERE customer_id = $1 AND credit_package_id = $2
+	)`
+
+	var exists bool
+	err := j.db.QueryRowContext(ctx, query, userID, packageID).Scan(&exists)
+	return exists, err
+}
+
+// reconcileCheckout processes a missed checkout
+func (j *CheckoutReconciliationJob) reconcileCheckout(ctx context.Context, session *stripe.CheckoutSession, userID uuid.UUID) error {
+	eventCreatedAt := time.Unix(session.Created, 0)
+
+	// Store Stripe customer ID if not already stored
+	if session.Customer != nil && session.Customer.ID != "" {
+		j.storeStripeCustomerID(userID, session.Customer.ID)
+	}
+
+	// Handle subscription checkout (membership)
+	if session.Mode == stripe.CheckoutSessionModeSubscription {
+		return j.reconcileMembershipCheckout(ctx, session, userID, eventCreatedAt)
+	}
+
+	// Handle one-time payment (credit package)
+	if session.Mode == stripe.CheckoutSessionModePayment {
+		return j.reconcileOneTimeCheckout(ctx, session, userID, eventCreatedAt)
+	}
+
+	return nil
+}
+
+// reconcileMembershipCheckout reconciles a missed membership subscription
+func (j *CheckoutReconciliationJob) reconcileMembershipCheckout(ctx context.Context, session *stripe.CheckoutSession, userID uuid.UUID, eventCreatedAt time.Time) error {
+	membershipPlanIDStr := session.Metadata["membershipPlanID"]
+	if membershipPlanIDStr == "" {
+		log.Printf("[CHECKOUT_RECONCILE] Missing membership plan ID in session metadata for session %s", session.ID)
+		return nil // Can't reconcile without plan ID
+	}
+
+	planID, err := uuid.Parse(membershipPlanIDStr)
+	if err != nil {
+		return err
+	}
+
+	// Get amt_periods from membership plan to calculate renewal date
+	amtPeriods, amtErr := j.postCheckoutRepository.GetMembershipPlanAmtPeriods(ctx, planID)
+	if amtErr != nil {
+		log.Printf("[CHECKOUT_RECONCILE] Warning: Could not get amt_periods for plan %s: %v", planID, amtErr)
+	}
+
+	subscriptionID := ""
+	var cancelAtDateTime time.Time
+	var nextBillingDate time.Time
+
+	// Get subscription details from Stripe for proper dates
+	if session.Subscription != nil {
+		subscriptionID = session.Subscription.ID
+
+		// Fetch full subscription details from Stripe
+		sub, subErr := subscription.Get(subscriptionID, nil)
+		if subErr != nil {
+			log.Printf("[CHECKOUT_RECONCILE] Warning: Could not fetch subscription %s from Stripe: %v", subscriptionID, subErr)
+		} else {
+			// Get next billing date from current period end
+			if sub.CurrentPeriodEnd > 0 {
+				nextBillingDate = time.Unix(sub.CurrentPeriodEnd, 0)
+			}
+
+			// If plan has amt_periods, calculate the renewal/cancel date
+			// This replicates the webhook's calculateCancelAt logic
+			if amtPeriods != nil && *amtPeriods > 0 && len(sub.Items.Data) > 0 {
+				item := sub.Items.Data[0]
+				if item.Price != nil && item.Price.Recurring != nil {
+					interval := item.Price.Recurring.Interval
+					intervalCount := int(item.Price.Recurring.IntervalCount)
+					periods := int(*amtPeriods)
+
+					log.Printf("[CHECKOUT_RECONCILE] Calculating cancel date: interval=%s, intervalCount=%d, periods=%d", interval, intervalCount, periods)
+
+					var cancelTime time.Time
+					switch interval {
+					case stripe.PriceRecurringIntervalMonth:
+						cancelTime = eventCreatedAt.AddDate(0, intervalCount*periods, 0)
+					case stripe.PriceRecurringIntervalYear:
+						cancelTime = eventCreatedAt.AddDate(intervalCount*periods, 0, 0)
+					case stripe.PriceRecurringIntervalWeek:
+						cancelTime = eventCreatedAt.AddDate(0, 0, 7*intervalCount*periods)
+					case stripe.PriceRecurringIntervalDay:
+						cancelTime = eventCreatedAt.AddDate(0, 0, intervalCount*periods)
+					default:
+						log.Printf("[CHECKOUT_RECONCILE] Unsupported billing interval: %s", interval)
+					}
+
+					if !cancelTime.IsZero() {
+						cancelAtDateTime = cancelTime
+						log.Printf("[CHECKOUT_RECONCILE] Calculated cancel date: %v", cancelAtDateTime)
+
+						// Update the Stripe subscription with the cancel date
+						_, updateErr := subscription.Update(subscriptionID, &stripe.SubscriptionParams{
+							CancelAt: stripe.Int64(cancelTime.Unix()),
+						})
+						if updateErr != nil {
+							log.Printf("[CHECKOUT_RECONCILE] Warning: Failed to update subscription cancel date in Stripe: %v", updateErr)
+						} else {
+							log.Printf("[CHECKOUT_RECONCILE] Updated Stripe subscription %s with cancel_at: %v", subscriptionID, cancelTime)
+						}
+					}
+				}
+			} else if sub.CancelAt > 0 {
+				// Fallback: use existing cancel date from Stripe if already set
+				cancelAtDateTime = time.Unix(sub.CancelAt, 0)
+			}
+
+			log.Printf("[CHECKOUT_RECONCILE] Got subscription dates - Next billing: %v, Cancel at: %v", nextBillingDate, cancelAtDateTime)
+		}
+	}
+
+	log.Printf("[CHECKOUT_RECONCILE] Enrolling customer %s in membership plan %s (subscription: %s)", userID, planID, subscriptionID)
+	return j.enrollmentService.EnrollCustomerInMembershipPlan(ctx, userID, planID, cancelAtDateTime, nextBillingDate, eventCreatedAt, subscriptionID)
+}
+
+// reconcileOneTimeCheckout reconciles a missed one-time payment
+func (j *CheckoutReconciliationJob) reconcileOneTimeCheckout(ctx context.Context, session *stripe.CheckoutSession, userID uuid.UUID, eventCreatedAt time.Time) error {
+	if session.LineItems == nil || len(session.LineItems.Data) == 0 {
+		return nil
+	}
+
+	for _, item := range session.LineItems.Data {
+		if item.Price == nil {
+			continue
+		}
+
+		priceID := item.Price.ID
+
+		// Check if this is a credit package
+		pkg, _ := j.creditPackageRepo.GetByStripePriceID(ctx, priceID)
+		if pkg != nil {
+			log.Printf("[CHECKOUT_RECONCILE] Adding %d credits to customer %s from package %s", pkg.CreditAllocation, userID, pkg.ID)
+
+			if err := j.customerCreditService.AddCredits(ctx, userID, pkg.CreditAllocation, "Credit package purchase (reconciled)"); err != nil {
+				return err
+			}
+
+			if err := j.creditPackageRepo.SetCustomerActivePackage(ctx, userID, pkg.ID, pkg.WeeklyCreditLimit); err != nil {
+				return err
+			}
+
+			log.Printf("[CHECKOUT_RECONCILE] Successfully reconciled credit package %s for customer %s", pkg.ID, userID)
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// getProductType determines the product type from the checkout session
+func (j *CheckoutReconciliationJob) getProductType(session *stripe.CheckoutSession) string {
+	if session.Mode == stripe.CheckoutSessionModeSubscription {
+		return "membership"
+	}
+
+	// For one-time payments, check line items
+	if session.LineItems != nil && len(session.LineItems.Data) > 0 {
+		for _, item := range session.LineItems.Data {
+			if item.Price != nil {
+				// Check if this is a credit package
+				pkg, _ := j.creditPackageRepo.GetByStripePriceID(context.Background(), item.Price.ID)
+				if pkg != nil {
+					return "credit_package"
+				}
+			}
+		}
+	}
+
+	return "one_time_payment"
+}
+
+// storeStripeCustomerID stores the Stripe customer ID for the user
+func (j *CheckoutReconciliationJob) storeStripeCustomerID(userID uuid.UUID, stripeCustomerID string) {
+	query := `UPDATE users.users SET stripe_customer_id = $1 WHERE id = $2 AND (stripe_customer_id IS NULL OR stripe_customer_id = '')`
+	_, err := j.db.Exec(query, stripeCustomerID, userID)
+	if err != nil {
+		log.Printf("[CHECKOUT_RECONCILE] Failed to store Stripe customer ID: %v", err)
+	}
+}
+
+// sendSummaryAlert sends a single summary alert for the reconciliation job run
+func (j *CheckoutReconciliationJob) sendSummaryAlert(reconciled int, errorCount int, failedSessions []string) {
+	// Only alert if something noteworthy happened
+	if reconciled == 0 && errorCount == 0 {
+		return
+	}
+
+	var alertType string
+	var message string
+
+	if errorCount > 0 && reconciled == 0 {
+		// Only failures
+		alertType = "RECONCILIATION_FAILURE"
+		message = fmt.Sprintf("Checkout reconciliation: %d failed (manual review needed)", errorCount)
+	} else if errorCount > 0 {
+		// Mixed results
+		alertType = "RECONCILIATION_PARTIAL"
+		message = fmt.Sprintf("Checkout reconciliation: %d recovered, %d failed", reconciled, errorCount)
+	} else {
+		// Only successes
+		alertType = "RECONCILIATION_SUCCESS"
+		message = fmt.Sprintf("Checkout reconciliation: %d missed checkouts recovered", reconciled)
+	}
+
+	// Build session list for failures (truncate if too many)
+	sessionList := ""
+	if len(failedSessions) > 0 {
+		if len(failedSessions) <= 3 {
+			sessionList = fmt.Sprintf(" Sessions: %v", failedSessions)
+		} else {
+			sessionList = fmt.Sprintf(" Sessions: %v... (+%d more)", failedSessions[:3], len(failedSessions)-3)
+		}
+	}
+
+	logger.SendReconciliationAlert(logger.ReconciliationAlertDetails{
+		AlertType:    alertType,
+		ErrorMessage: message + sessionList,
+		WasFixed:     reconciled > 0,
+		Product:      "checkout_reconciliation",
+	})
+}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
   - Add checkout reconciliation job that runs every 30 min to catch missed webhooks
   - Add checkout verification endpoint for frontend to verify enrollment after redirect
   - Calculate renewal_date from membership plan amt_periods × billing interval
   - Add webhook idempotency with database tracking to prevent duplicate processing
   - Add unique index on active memberships to prevent duplicate enrollments
   - Improve cancel URL handling to redirect back to checkout page on cancel
   - Add User-Agent and localhost validation for webhook security
   - Consolidate Slack alerts to single summary per reconciliation run
   - Add subscription cancel date updates to Stripe during reconciliation

---

# 🧠 Reason for Changes

  Safety net for Stripe payment processing reliability. Webhooks can fail silently due to network issues, timeouts,
  or Stripe outages - leaving customers who paid without their membership enrollment. The reconciliation system
  ensures:

  1. No lost payments - If webhook fails, the 30-min job catches it and enrolls the customer
  2. No duplicate enrollments - Idempotency tracking + unique index prevents double-processing
  3. Correct renewal dates - Calculates from plan's amt_periods instead of relying solely on webhook data
  4. Security hardening - Validates webhook requests come from Stripe, not localhost or missing User-Agent
  5. Reduced alert noise - One summary Slack notification per job run instead of per-session

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [X] Backend APIs tested via Postman
- [ ] No console errors (Frontend)
- [X] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
Example: `https://trello.com/c/your-task-id`

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

