### PR TITLE
Add active_members_count to

### DIFF
--- a/internal/domains/user/handler/customer_handler.go
+++ b/internal/domains/user/handler/customer_handler.go
@@ -276,6 +276,13 @@ func (h *CustomersHandler) GetCustomers(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Fetch active members count
+	activeMembersCount, err := h.CustomerRepo.CountActiveMembers(r.Context())
+	if err != nil {
+		responseHandlers.RespondWithError(w, errLib.New("Failed to count active members: "+err.Error(), http.StatusInternalServerError))
+		return
+	}
+
 	// Map results
 	result := make([]customerDto.Response, len(dbCustomers))
 	for i, customer := range dbCustomers {
@@ -284,11 +291,12 @@ func (h *CustomersHandler) GetCustomers(w http.ResponseWriter, r *http.Request) 
 
 	// Compose response with pagination metadata
 	response := map[string]interface{}{
-		"data":  result,
-		"page":  page,
-		"limit": limit,
-		"total": totalCount,
-		"pages": int((totalCount + int64(limit) - 1) / int64(limit)), // ceil(total / limit)
+		"data":                 result,
+		"page":                 page,
+		"limit":                limit,
+		"total":                totalCount,
+		"pages":                int((totalCount + int64(limit) - 1) / int64(limit)), // ceil(total / limit)
+		"active_members_count": activeMembersCount,
 	}
 
 	responseHandlers.RespondWithSuccess(w, response, http.StatusOK)

--- a/internal/domains/user/persistence/repository/customer_repository.go
+++ b/internal/domains/user/persistence/repository/customer_repository.go
@@ -413,6 +413,15 @@ func (r *CustomerRepository) CountCustomers(ctx context.Context, parentID uuid.U
 	return count, nil
 }
 
+func (r *CustomerRepository) CountActiveMembers(ctx context.Context) (int64, *errLib.CommonError) {
+	count, err := r.Queries.CountActiveMembers(ctx)
+	if err != nil {
+		return 0, errLib.New("Failed to count active members: "+err.Error(), http.StatusInternalServerError)
+	}
+
+	return count, nil
+}
+
 func (r *CustomerRepository) GetActiveMembershipInfo(ctx context.Context, customerID uuid.UUID) (*userValues.MembershipPlansReadValue, *errLib.CommonError) {
 	row, err := r.Queries.GetActiveMembershipInfo(ctx, customerID)
 	if err != nil {

--- a/internal/domains/user/persistence/sqlc/queries/customer.sql
+++ b/internal/domains/user/persistence/sqlc/queries/customer.sql
@@ -289,3 +289,11 @@ SELECT *
 FROM users.customer_membership_plans
 WHERE square_subscription_id = sqlc.arg('subscription_id')
 LIMIT 1;
+
+-- name: CountActiveMembers :one
+SELECT COUNT(DISTINCT cmp.customer_id)
+FROM users.customer_membership_plans cmp
+JOIN users.users u ON u.id = cmp.customer_id
+WHERE cmp.status = 'active'
+  AND u.is_archived = FALSE
+  AND NOT EXISTS (SELECT 1 FROM staff.staff s WHERE s.id = u.id);


### PR DESCRIPTION
  # ✨ Changes Made

  - Added `CountActiveMembers` SQL query to count distinct customers with active memberships
  - Added `CountActiveMembers` repository method
  - Updated `GetCustomers` handler to include `active_members_count` in response

  ---

  # 🧠 Reason for Changes

  The `/customers` endpoint returns total customer count, but we needed a way to get the count of customers with active memberships (`status = 'active'`) for dashboard/reporting purposes.

  ---

  # 🧪 Testing Performed

  - [ ] Frontend tested locally (`npm run dev`)
  - [ ] Mobile App tested via Expo / emulator
  - [ ] Backend APIs tested via Postman
  - [ ] No console errors (Frontend)
  - [ ] No server errors (Backend)
  - [ ] Mobile app builds successfully (if applicable)

  ---

  # 🗒️ Notes for Reviewer (Optional)

  The `active_members_count` field counts distinct customers where:
  - `customer_membership_plans.status = 'active'`
  - User is not archived
  - User is not staff