### PR TITLE
Add Firebase orphan cleanup job and admin endpoint

### DIFF
--- a/internal/domains/admin/handler/firebase_cleanup_handler.go
+++ b/internal/domains/admin/handler/firebase_cleanup_handler.go
@@ -1,0 +1,67 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"api/internal/di"
+	"api/internal/jobs"
+)
+
+// FirebaseCleanupResponse contains the results of a Firebase cleanup operation
+type FirebaseCleanupResponse struct {
+	TotalFirebaseUsers int      `json:"total_firebase_users"`
+	TotalDBUsers       int      `json:"total_db_users"`
+	OrphanedCount      int      `json:"orphaned_count"`
+	DeletedCount       int      `json:"deleted_count"`
+	FailedCount        int      `json:"failed_count"`
+	DryRun             bool     `json:"dry_run"`
+	OrphanedEmails     []string `json:"orphaned_emails,omitempty"`
+	Errors             []string `json:"errors,omitempty"`
+}
+
+type FirebaseCleanupHandler struct {
+	container *di.Container
+}
+
+func NewFirebaseCleanupHandler(container *di.Container) *FirebaseCleanupHandler {
+	return &FirebaseCleanupHandler{
+		container: container,
+	}
+}
+
+// CleanupOrphanedFirebaseUsers handles the Firebase cleanup request
+// @Summary Clean up orphaned Firebase users
+// @Description Finds and optionally deletes Firebase users that don't exist in the database
+// @Tags admin
+// @Accept json
+// @Produce json
+// @Param dry_run query bool false "If true, only report what would be deleted without actually deleting (default: true)"
+// @Success 200 {object} FirebaseCleanupResponse "Cleanup result"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /admin/firebase/cleanup [post]
+// @Security Bearer
+func (h *FirebaseCleanupHandler) CleanupOrphanedFirebaseUsers(w http.ResponseWriter, r *http.Request) {
+	// Default to dry run for safety
+	dryRun := true
+	if r.URL.Query().Get("dry_run") == "false" {
+		dryRun = false
+	}
+
+	// Create and configure the cleanup job
+	job := jobs.NewFirebaseCleanupJob(h.container)
+	job.SetDryRun(dryRun)
+
+	// Run the cleanup
+	result, err := job.RunWithResult(r.Context())
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "Failed to run cleanup: " + err.Error(),
+		})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(result)
+}

--- a/internal/jobs/firebase_cleanup.go
+++ b/internal/jobs/firebase_cleanup.go
@@ -1,0 +1,188 @@
+package jobs
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"time"
+
+	"api/internal/di"
+
+	"firebase.google.com/go/auth"
+	"google.golang.org/api/iterator"
+)
+
+// FirebaseCleanupJob finds and removes Firebase users that don't exist in the database
+type FirebaseCleanupJob struct {
+	db                 *sql.DB
+	firebaseAuthClient *auth.Client
+	dryRun             bool
+}
+
+// FirebaseCleanupResult contains the results of a cleanup operation
+type FirebaseCleanupResult struct {
+	TotalFirebaseUsers int      `json:"total_firebase_users"`
+	TotalDBUsers       int      `json:"total_db_users"`
+	OrphanedCount      int      `json:"orphaned_count"`
+	DeletedCount       int      `json:"deleted_count"`
+	FailedCount        int      `json:"failed_count"`
+	DryRun             bool     `json:"dry_run"`
+	OrphanedEmails     []string `json:"orphaned_emails,omitempty"`
+	Errors             []string `json:"errors,omitempty"`
+}
+
+// NewFirebaseCleanupJob creates a new Firebase cleanup job
+func NewFirebaseCleanupJob(container *di.Container) *FirebaseCleanupJob {
+	return &FirebaseCleanupJob{
+		db:                 container.DB,
+		firebaseAuthClient: container.FirebaseService.FirebaseAuthClient,
+		dryRun:             true, // Default to dry run for safety
+	}
+}
+
+// Name returns the job name
+func (j *FirebaseCleanupJob) Name() string {
+	return "FirebaseCleanup"
+}
+
+// Interval returns how often this job runs (once per day)
+func (j *FirebaseCleanupJob) Interval() time.Duration {
+	return 24 * time.Hour
+}
+
+// SetDryRun allows toggling dry run mode
+func (j *FirebaseCleanupJob) SetDryRun(dryRun bool) {
+	j.dryRun = dryRun
+}
+
+// Run executes the Firebase cleanup logic
+func (j *FirebaseCleanupJob) Run(ctx context.Context) error {
+	result, err := j.RunWithResult(ctx)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[FIREBASE-CLEANUP] Summary: firebase_users=%d, db_users=%d, orphaned=%d, deleted=%d, failed=%d, dry_run=%v",
+		result.TotalFirebaseUsers, result.TotalDBUsers, result.OrphanedCount, result.DeletedCount, result.FailedCount, result.DryRun)
+
+	return nil
+}
+
+// RunWithResult executes the cleanup and returns detailed results
+func (j *FirebaseCleanupJob) RunWithResult(ctx context.Context) (*FirebaseCleanupResult, error) {
+	result := &FirebaseCleanupResult{
+		DryRun:         j.dryRun,
+		OrphanedEmails: []string{},
+		Errors:         []string{},
+	}
+
+	if j.dryRun {
+		log.Printf("[FIREBASE-CLEANUP] Starting cleanup in DRY RUN mode - no users will be deleted")
+	} else {
+		log.Printf("[FIREBASE-CLEANUP] Starting cleanup - orphaned Firebase users will be deleted")
+	}
+
+	// 1. Get all emails from database
+	dbEmails, err := j.getAllDBEmails(ctx)
+	if err != nil {
+		log.Printf("[FIREBASE-CLEANUP] Failed to get database emails: %v", err)
+		return nil, err
+	}
+	result.TotalDBUsers = len(dbEmails)
+	log.Printf("[FIREBASE-CLEANUP] Found %d users in database", len(dbEmails))
+
+	// Create a set for fast lookup
+	dbEmailSet := make(map[string]bool)
+	for _, email := range dbEmails {
+		dbEmailSet[email] = true
+	}
+
+	// 2. Iterate through Firebase users and find orphaned ones
+	orphanedUsers := []struct {
+		UID   string
+		Email string
+	}{}
+
+	iter := j.firebaseAuthClient.Users(ctx, "")
+	for {
+		user, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Printf("[FIREBASE-CLEANUP] Error iterating Firebase users: %v", err)
+			result.Errors = append(result.Errors, "Iterator error: "+err.Error())
+			break
+		}
+
+		result.TotalFirebaseUsers++
+
+		// Check if Firebase user exists in database
+		if user.Email != "" && !dbEmailSet[user.Email] {
+			orphanedUsers = append(orphanedUsers, struct {
+				UID   string
+				Email string
+			}{UID: user.UID, Email: user.Email})
+			result.OrphanedEmails = append(result.OrphanedEmails, user.Email)
+			log.Printf("[FIREBASE-CLEANUP] Found orphaned Firebase user: %s (%s)", user.UID, user.Email)
+		}
+	}
+
+	result.OrphanedCount = len(orphanedUsers)
+	log.Printf("[FIREBASE-CLEANUP] Found %d orphaned Firebase users out of %d total", result.OrphanedCount, result.TotalFirebaseUsers)
+
+	// 3. Delete orphaned users (if not dry run)
+	if !j.dryRun {
+		for _, orphan := range orphanedUsers {
+			if err := j.firebaseAuthClient.DeleteUser(ctx, orphan.UID); err != nil {
+				log.Printf("[FIREBASE-CLEANUP] Failed to delete Firebase user %s (%s): %v", orphan.UID, orphan.Email, err)
+				result.Errors = append(result.Errors, "Delete failed for "+orphan.Email+": "+err.Error())
+				result.FailedCount++
+			} else {
+				log.Printf("[FIREBASE-CLEANUP] Successfully deleted orphaned Firebase user: %s (%s)", orphan.UID, orphan.Email)
+				result.DeletedCount++
+			}
+		}
+	} else {
+		log.Printf("[FIREBASE-CLEANUP] DRY RUN: Would have deleted %d orphaned Firebase users", result.OrphanedCount)
+	}
+
+	return result, nil
+}
+
+// getAllDBEmails fetches all user emails from the database (including pending staff)
+func (j *FirebaseCleanupJob) getAllDBEmails(ctx context.Context) ([]string, error) {
+	// Query emails from users table and pending_staff table
+	// Staff are already in users.users (staff.staff references users.users)
+	// Pending staff have registered in Firebase but aren't approved yet
+	// We include them here so they are NOT deleted from Firebase
+	rows, err := j.db.QueryContext(ctx, `
+		SELECT email FROM users.users
+		WHERE email IS NOT NULL
+		  AND email != ''
+		  AND deleted_at IS NULL
+		UNION
+		SELECT email FROM staff.pending_staff
+		WHERE email IS NOT NULL
+		  AND email != ''
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var emails []string
+	for rows.Next() {
+		var email string
+		if err := rows.Scan(&email); err != nil {
+			return nil, err
+		}
+		emails = append(emails, email)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return emails, nil
+}


### PR DESCRIPTION
This adds functionality to identify and remove Firebase Authentication accounts that don't have a corresponding user record in the database. This handles cases where users started the signup process (created a Firebase account) but never completed registration in our system.

## New Files

### internal/jobs/firebase_cleanup.go
- FirebaseCleanupJob: Scheduled job that can run periodically
- Iterates through all Firebase Auth users
- Compares against emails in users.users and staff.pending_staff tables
- Pending staff are protected (included in valid email list) so they won't be deleted even if approval takes a while
- Supports dry-run mode (default) for safe testing
- Returns detailed results including list of orphaned emails

### internal/domains/admin/handler/firebase_cleanup_handler.go
- HTTP handler to trigger cleanup manually via API
- Endpoint: POST /admin/firebase/cleanup
- Query param: dry_run (default: true)
  - true: Only report what would be deleted (safe mode)
  - false: Actually delete orphaned Firebase accounts
- Restricted to SuperAdmin and IT roles only

## Modified Files

### cmd/server/router/router.go
- Added import for new admin handler package
- Registered new endpoint in RegisterAdminRoutes

## Usage

1. Deploy and test with dry run (default): POST /admin/firebase/cleanup

2. Review the response to verify orphaned accounts are correct

3. If satisfied, run actual cleanup: POST /admin/firebase/cleanup?dry_run=false

## Response Format
{
  "total_firebase_users": 150,
  "total_db_users": 145,
  "orphaned_count": 5,
  "deleted_count": 0,
  "failed_count": 0,
  "dry_run": true,
  "orphaned_emails": ["email1@example.com", ...],
  "errors": []
}

