### PR TITLE
Add event notification feature for sending emails/push to attendees

### DIFF
--- a/db/migrations/20260106180000_event_notifications.sql
+++ b/db/migrations/20260106180000_event_notifications.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Event Notification History
+-- Tracks notifications sent to event attendees for auditing purposes
+
+CREATE TABLE IF NOT EXISTS events.notification_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_id UUID NOT NULL REFERENCES events.events(id) ON DELETE CASCADE,
+    sent_by UUID NOT NULL REFERENCES users.users(id),
+    channel VARCHAR(20) NOT NULL CHECK (channel IN ('email', 'push', 'both')),
+    subject VARCHAR(255),
+    message TEXT NOT NULL,
+    include_event_details BOOLEAN NOT NULL DEFAULT false,
+    recipient_count INT NOT NULL DEFAULT 0,
+    email_success_count INT NOT NULL DEFAULT 0,
+    email_failure_count INT NOT NULL DEFAULT 0,
+    push_success_count INT NOT NULL DEFAULT 0,
+    push_failure_count INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Index for querying notification history by event
+CREATE INDEX IF NOT EXISTS idx_notification_history_event_id ON events.notification_history(event_id);
+
+-- Index for querying notification history by sender
+CREATE INDEX IF NOT EXISTS idx_notification_history_sent_by ON events.notification_history(sent_by);
+
+COMMENT ON TABLE events.notification_history IS 'Tracks notifications sent to event attendees';
+COMMENT ON COLUMN events.notification_history.channel IS 'Notification channel: email, push, or both';
+COMMENT ON COLUMN events.notification_history.include_event_details IS 'Whether event details were automatically included in the message';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TABLE IF EXISTS events.notification_history;
+
+-- +goose StatementEnd

--- a/internal/domains/event/dto/notification_dto.go
+++ b/internal/domains/event/dto/notification_dto.go
@@ -1,0 +1,90 @@
+package event
+
+import (
+	"net/http"
+
+	errLib "api/internal/libs/errors"
+	"api/internal/libs/validators"
+
+	"github.com/google/uuid"
+)
+
+// NotificationChannel represents the notification delivery channel
+type NotificationChannel string
+
+const (
+	ChannelEmail NotificationChannel = "email"
+	ChannelPush  NotificationChannel = "push"
+	ChannelBoth  NotificationChannel = "both"
+)
+
+// SendNotificationRequestDto is the request body for sending notifications to event attendees
+type SendNotificationRequestDto struct {
+	Channel             string      `json:"channel" validate:"required,oneof=email push both" example:"both"`
+	Subject             string      `json:"subject" example:"Event Update"`
+	Message             string      `json:"message" validate:"required" example:"Important update about your upcoming event..."`
+	IncludeEventDetails bool        `json:"include_event_details" example:"true"`
+	CustomerIDs         []uuid.UUID `json:"customer_ids" example:"[\"f0e21457-75d4-4de6-b765-5ee13221fd72\"]"` // nil = all enrolled
+}
+
+// Validate validates the notification request
+func (dto *SendNotificationRequestDto) Validate() *errLib.CommonError {
+	if err := validators.ValidateDto(dto); err != nil {
+		return err
+	}
+
+	// Subject is required for email
+	if (dto.Channel == string(ChannelEmail) || dto.Channel == string(ChannelBoth)) && dto.Subject == "" {
+		return errLib.New("subject is required for email notifications", http.StatusBadRequest)
+	}
+
+	return nil
+}
+
+// SendNotificationResponseDto is the response after sending notifications
+type SendNotificationResponseDto struct {
+	NotificationID uuid.UUID `json:"notification_id"`
+	RecipientCount int       `json:"recipient_count"`
+	EmailSent      int       `json:"email_sent"`
+	EmailFailed    int       `json:"email_failed"`
+	PushSent       int       `json:"push_sent"`
+	PushFailed     int       `json:"push_failed"`
+}
+
+// NotificationHistoryDto represents a notification in the history
+type NotificationHistoryDto struct {
+	ID                  uuid.UUID `json:"id"`
+	EventID             uuid.UUID `json:"event_id"`
+	SentBy              uuid.UUID `json:"sent_by"`
+	SentByName          string    `json:"sent_by_name"`
+	Channel             string    `json:"channel"`
+	Subject             string    `json:"subject,omitempty"`
+	Message             string    `json:"message"`
+	IncludeEventDetails bool      `json:"include_event_details"`
+	RecipientCount      int       `json:"recipient_count"`
+	EmailSuccessCount   int       `json:"email_success_count"`
+	EmailFailureCount   int       `json:"email_failure_count"`
+	PushSuccessCount    int       `json:"push_success_count"`
+	PushFailureCount    int       `json:"push_failure_count"`
+	CreatedAt           string    `json:"created_at"`
+}
+
+// EventCustomerDto represents an enrolled customer for an event
+type EventCustomerDto struct {
+	ID           uuid.UUID `json:"id"`
+	FirstName    string    `json:"first_name"`
+	LastName     string    `json:"last_name"`
+	Email        string    `json:"email"`
+	HasPushToken bool      `json:"has_push_token"`
+}
+
+// EventCustomersResponseDto is the response for getting enrolled customers
+type EventCustomersResponseDto struct {
+	TotalCount int                `json:"total_count"`
+	Customers  []EventCustomerDto `json:"customers"`
+}
+
+// NotificationHistoryResponseDto is the response for getting notification history
+type NotificationHistoryResponseDto struct {
+	Notifications []NotificationHistoryDto `json:"notifications"`
+}

--- a/internal/domains/event/handler/notification_handler.go
+++ b/internal/domains/event/handler/notification_handler.go
@@ -1,0 +1,238 @@
+package event
+
+import (
+	"net/http"
+
+	"api/internal/di"
+	dto "api/internal/domains/event/dto"
+	"api/internal/domains/event/service"
+	errLib "api/internal/libs/errors"
+	responseHandlers "api/internal/libs/responses"
+	"api/internal/libs/validators"
+	contextUtils "api/utils/context"
+
+	"github.com/go-chi/chi"
+	"github.com/google/uuid"
+)
+
+// EventNotificationHandler provides HTTP handlers for event notifications
+type EventNotificationHandler struct {
+	notificationService *service.EventNotificationService
+}
+
+// NewEventNotificationHandler creates a new EventNotificationHandler
+func NewEventNotificationHandler(container *di.Container) *EventNotificationHandler {
+	return &EventNotificationHandler{
+		notificationService: service.NewEventNotificationService(container),
+	}
+}
+
+// GetEventCustomers retrieves all enrolled customers for an event
+// @Summary Get enrolled customers for an event
+// @Description Returns all customers enrolled in an event with their email and push notification status
+// @Tags event-notifications
+// @Accept json
+// @Produce json
+// @Param event_id path string true "Event ID" Format(uuid)
+// @Success 200 {object} dto.EventCustomersResponseDto "List of enrolled customers"
+// @Failure 400 {object} map[string]interface{} "Bad Request: Invalid event ID"
+// @Failure 404 {object} map[string]interface{} "Not Found: Event not found"
+// @Failure 500 {object} map[string]interface{} "Internal Server Error"
+// @Router /events/{event_id}/customers [get]
+// @Security Bearer
+func (h *EventNotificationHandler) GetEventCustomers(w http.ResponseWriter, r *http.Request) {
+	eventID, err := h.parseEventID(r)
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	// Check coach authorization
+	if authErr := h.checkCoachAuthorization(r, eventID); authErr != nil {
+		responseHandlers.RespondWithError(w, authErr)
+		return
+	}
+
+	customers, err := h.notificationService.GetEventCustomers(r.Context(), eventID)
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	// Convert to DTO
+	customerDtos := make([]dto.EventCustomerDto, len(customers))
+	for i, c := range customers {
+		customerDtos[i] = dto.EventCustomerDto{
+			ID:           c.ID,
+			FirstName:    c.FirstName,
+			LastName:     c.LastName,
+			Email:        c.Email,
+			HasPushToken: c.HasPushToken,
+		}
+	}
+
+	response := dto.EventCustomersResponseDto{
+		TotalCount: len(customerDtos),
+		Customers:  customerDtos,
+	}
+
+	responseHandlers.RespondWithSuccess(w, response, http.StatusOK)
+}
+
+// SendNotification sends email and/or push notifications to event attendees
+// @Summary Send notification to event attendees
+// @Description Sends email and/or push notifications to customers enrolled in an event
+// @Tags event-notifications
+// @Accept json
+// @Produce json
+// @Param event_id path string true "Event ID" Format(uuid)
+// @Param notification body dto.SendNotificationRequestDto true "Notification details"
+// @Success 200 {object} dto.SendNotificationResponseDto "Notification send result"
+// @Failure 400 {object} map[string]interface{} "Bad Request: Invalid input"
+// @Failure 403 {object} map[string]interface{} "Forbidden: Insufficient permissions"
+// @Failure 404 {object} map[string]interface{} "Not Found: Event not found"
+// @Failure 500 {object} map[string]interface{} "Internal Server Error"
+// @Router /events/{event_id}/notifications [post]
+// @Security Bearer
+func (h *EventNotificationHandler) SendNotification(w http.ResponseWriter, r *http.Request) {
+	eventID, err := h.parseEventID(r)
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	// Check coach authorization
+	if authErr := h.checkCoachAuthorization(r, eventID); authErr != nil {
+		responseHandlers.RespondWithError(w, authErr)
+		return
+	}
+
+	// Parse request body
+	var requestDto dto.SendNotificationRequestDto
+	if err := validators.ParseJSON(r.Body, &requestDto); err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	// Validate request
+	if err := requestDto.Validate(); err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	// Get sender ID from context
+	senderID, idErr := contextUtils.GetUserID(r.Context())
+	if idErr != nil {
+		responseHandlers.RespondWithError(w, errLib.New("Failed to get user ID", http.StatusUnauthorized))
+		return
+	}
+
+	// Send notification
+	result, err := h.notificationService.SendNotification(r.Context(), eventID, senderID, requestDto)
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	response := dto.SendNotificationResponseDto{
+		NotificationID: result.NotificationID,
+		RecipientCount: result.RecipientCount,
+		EmailSent:      result.EmailSent,
+		EmailFailed:    result.EmailFailed,
+		PushSent:       result.PushSent,
+		PushFailed:     result.PushFailed,
+	}
+
+	responseHandlers.RespondWithSuccess(w, response, http.StatusOK)
+}
+
+// GetNotificationHistory retrieves notification history for an event
+// @Summary Get notification history for an event
+// @Description Returns all notifications that have been sent for an event
+// @Tags event-notifications
+// @Accept json
+// @Produce json
+// @Param event_id path string true "Event ID" Format(uuid)
+// @Success 200 {object} dto.NotificationHistoryResponseDto "Notification history"
+// @Failure 400 {object} map[string]interface{} "Bad Request: Invalid event ID"
+// @Failure 404 {object} map[string]interface{} "Not Found: Event not found"
+// @Failure 500 {object} map[string]interface{} "Internal Server Error"
+// @Router /events/{event_id}/notifications [get]
+// @Security Bearer
+func (h *EventNotificationHandler) GetNotificationHistory(w http.ResponseWriter, r *http.Request) {
+	eventID, err := h.parseEventID(r)
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	// Check coach authorization
+	if authErr := h.checkCoachAuthorization(r, eventID); authErr != nil {
+		responseHandlers.RespondWithError(w, authErr)
+		return
+	}
+
+	history, err := h.notificationService.GetNotificationHistory(r.Context(), eventID)
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	if history == nil {
+		history = []dto.NotificationHistoryDto{}
+	}
+
+	response := dto.NotificationHistoryResponseDto{
+		Notifications: history,
+	}
+
+	responseHandlers.RespondWithSuccess(w, response, http.StatusOK)
+}
+
+// parseEventID extracts and validates the event ID from the URL
+func (h *EventNotificationHandler) parseEventID(r *http.Request) (uuid.UUID, *errLib.CommonError) {
+	eventIDStr := chi.URLParam(r, "event_id")
+	if eventIDStr == "" {
+		return uuid.Nil, errLib.New("Event ID is required", http.StatusBadRequest)
+	}
+
+	eventID, err := validators.ParseUUID(eventIDStr)
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	return eventID, nil
+}
+
+// checkCoachAuthorization verifies that coaches can only access their own events
+func (h *EventNotificationHandler) checkCoachAuthorization(r *http.Request, eventID uuid.UUID) *errLib.CommonError {
+	role, err := contextUtils.GetUserRole(r.Context())
+	if err != nil {
+		return errLib.New("Failed to get user role", http.StatusUnauthorized)
+	}
+
+	// Admins, SuperAdmins, IT, and Receptionists have full access
+	if role == contextUtils.RoleAdmin || role == contextUtils.RoleSuperAdmin ||
+		role == contextUtils.RoleIT || role == contextUtils.RoleReceptionist {
+		return nil
+	}
+
+	// Coaches need to be verified for access
+	if role == contextUtils.RoleCoach {
+		staffID, idErr := contextUtils.GetUserID(r.Context())
+		if idErr != nil {
+			return errLib.New("Failed to get user ID", http.StatusUnauthorized)
+		}
+
+		hasAccess, accessErr := h.notificationService.CheckCoachHasAccessToEvent(r.Context(), eventID, staffID)
+		if accessErr != nil {
+			return accessErr
+		}
+
+		if !hasAccess {
+			return errLib.New("You do not have access to this event", http.StatusForbidden)
+		}
+	}
+
+	return nil
+}

--- a/internal/domains/event/persistence/sqlc/queries/notification_queries.sql
+++ b/internal/domains/event/persistence/sqlc/queries/notification_queries.sql
@@ -1,0 +1,118 @@
+-- name: GetEventEnrolledCustomers :many
+-- Get all enrolled customers for an event with their email and push token status
+SELECT
+    u.id,
+    u.first_name,
+    u.last_name,
+    u.email,
+    EXISTS(SELECT 1 FROM notifications.push_tokens pt WHERE pt.user_id = u.id) AS has_push_token
+FROM events.customer_enrollment ce
+JOIN users.users u ON ce.customer_id = u.id
+WHERE ce.event_id = $1
+  AND ce.is_cancelled = false
+  AND ce.payment_status = 'paid'
+ORDER BY u.last_name, u.first_name;
+
+-- name: GetEventEnrolledCustomerEmails :many
+-- Get emails of all enrolled customers for an event (for email sending)
+SELECT
+    u.id,
+    u.first_name,
+    u.email
+FROM events.customer_enrollment ce
+JOIN users.users u ON ce.customer_id = u.id
+WHERE ce.event_id = $1
+  AND ce.is_cancelled = false
+  AND ce.payment_status = 'paid'
+  AND u.email IS NOT NULL
+  AND u.email != '';
+
+-- name: GetEventEnrolledCustomerPushTokens :many
+-- Get push tokens of all enrolled customers for an event (for push notifications)
+SELECT
+    u.id AS user_id,
+    u.first_name,
+    pt.expo_push_token,
+    pt.device_type
+FROM events.customer_enrollment ce
+JOIN users.users u ON ce.customer_id = u.id
+JOIN notifications.push_tokens pt ON pt.user_id = u.id
+WHERE ce.event_id = $1
+  AND ce.is_cancelled = false
+  AND ce.payment_status = 'paid';
+
+-- name: GetEventEnrolledCustomersByIDs :many
+-- Get specific enrolled customers by their IDs
+SELECT
+    u.id,
+    u.first_name,
+    u.last_name,
+    u.email,
+    EXISTS(SELECT 1 FROM notifications.push_tokens pt WHERE pt.user_id = u.id) AS has_push_token
+FROM events.customer_enrollment ce
+JOIN users.users u ON ce.customer_id = u.id
+WHERE ce.event_id = $1
+  AND ce.is_cancelled = false
+  AND ce.payment_status = 'paid'
+  AND u.id = ANY($2::uuid[])
+ORDER BY u.last_name, u.first_name;
+
+-- name: CreateNotificationHistory :one
+-- Record a notification in the history
+INSERT INTO events.notification_history (
+    event_id,
+    sent_by,
+    channel,
+    subject,
+    message,
+    include_event_details,
+    recipient_count,
+    email_success_count,
+    email_failure_count,
+    push_success_count,
+    push_failure_count
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+RETURNING *;
+
+-- name: GetNotificationHistoryByEvent :many
+-- Get notification history for an event
+SELECT
+    nh.id,
+    nh.event_id,
+    nh.sent_by,
+    u.first_name || ' ' || u.last_name AS sent_by_name,
+    nh.channel,
+    nh.subject,
+    nh.message,
+    nh.include_event_details,
+    nh.recipient_count,
+    nh.email_success_count,
+    nh.email_failure_count,
+    nh.push_success_count,
+    nh.push_failure_count,
+    nh.created_at
+FROM events.notification_history nh
+JOIN users.users u ON nh.sent_by = u.id
+WHERE nh.event_id = $1
+ORDER BY nh.created_at DESC;
+
+-- name: GetEventEnrollmentCount :one
+-- Get the count of enrolled customers for an event
+SELECT COUNT(*) AS count
+FROM events.customer_enrollment ce
+WHERE ce.event_id = $1
+  AND ce.is_cancelled = false
+  AND ce.payment_status = 'paid';
+
+-- name: CheckCoachHasAccessToEvent :one
+-- Check if a coach (staff) has access to an event (via team or direct assignment)
+SELECT EXISTS(
+    SELECT 1 FROM events.events e
+    LEFT JOIN athletic.teams t ON e.team_id = t.id
+    LEFT JOIN events.staff es ON es.event_id = e.id
+    WHERE e.id = $1
+      AND (
+        t.coach_id = $2  -- Coach of the team associated with event
+        OR es.staff_id = $2  -- Directly assigned to event
+      )
+) AS has_access;

--- a/internal/domains/event/service/notification_service.go
+++ b/internal/domains/event/service/notification_service.go
@@ -1,0 +1,504 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"api/internal/di"
+	dto "api/internal/domains/event/dto"
+	errLib "api/internal/libs/errors"
+	"api/utils/email"
+
+	"github.com/google/uuid"
+)
+
+// EventNotificationService handles sending notifications to event attendees
+type EventNotificationService struct {
+	db *sql.DB
+}
+
+// NewEventNotificationService creates a new EventNotificationService
+func NewEventNotificationService(container *di.Container) *EventNotificationService {
+	return &EventNotificationService{
+		db: container.DB,
+	}
+}
+
+// EventCustomer represents a customer enrolled in an event
+type EventCustomer struct {
+	ID           uuid.UUID
+	FirstName    string
+	LastName     string
+	Email        string
+	HasPushToken bool
+}
+
+// EventCustomerEmail represents customer data for email sending
+type EventCustomerEmail struct {
+	ID        uuid.UUID
+	FirstName string
+	Email     string
+}
+
+// EventCustomerPushToken represents customer push token data
+type EventCustomerPushToken struct {
+	UserID         uuid.UUID
+	FirstName      string
+	ExpoPushToken  string
+	DeviceType     string
+}
+
+// NotificationResult tracks the results of sending notifications
+type NotificationResult struct {
+	NotificationID uuid.UUID
+	RecipientCount int
+	EmailSent      int
+	EmailFailed    int
+	PushSent       int
+	PushFailed     int
+}
+
+// GetEventCustomers retrieves all enrolled customers for an event
+func (s *EventNotificationService) GetEventCustomers(ctx context.Context, eventID uuid.UUID) ([]EventCustomer, *errLib.CommonError) {
+	query := `
+		SELECT
+			u.id,
+			u.first_name,
+			u.last_name,
+			u.email,
+			EXISTS(SELECT 1 FROM notifications.push_tokens pt WHERE pt.user_id = u.id) AS has_push_token
+		FROM events.customer_enrollment ce
+		JOIN users.users u ON ce.customer_id = u.id
+		WHERE ce.event_id = $1
+		  AND ce.is_cancelled = false
+		  AND ce.payment_status = 'paid'
+		ORDER BY u.last_name, u.first_name
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, eventID)
+	if err != nil {
+		log.Printf("[EVENT-NOTIFICATION] Error querying enrolled customers: %v", err)
+		return nil, errLib.New("Failed to get enrolled customers", http.StatusInternalServerError)
+	}
+	defer rows.Close()
+
+	var customers []EventCustomer
+	for rows.Next() {
+		var c EventCustomer
+		var emailNull sql.NullString
+		if err := rows.Scan(&c.ID, &c.FirstName, &c.LastName, &emailNull, &c.HasPushToken); err != nil {
+			log.Printf("[EVENT-NOTIFICATION] Error scanning customer row: %v", err)
+			continue
+		}
+		if emailNull.Valid {
+			c.Email = emailNull.String
+		}
+		customers = append(customers, c)
+	}
+
+	return customers, nil
+}
+
+// GetEventCustomersByIDs retrieves specific enrolled customers by their IDs
+func (s *EventNotificationService) GetEventCustomersByIDs(ctx context.Context, eventID uuid.UUID, customerIDs []uuid.UUID) ([]EventCustomer, *errLib.CommonError) {
+	query := `
+		SELECT
+			u.id,
+			u.first_name,
+			u.last_name,
+			u.email,
+			EXISTS(SELECT 1 FROM notifications.push_tokens pt WHERE pt.user_id = u.id) AS has_push_token
+		FROM events.customer_enrollment ce
+		JOIN users.users u ON ce.customer_id = u.id
+		WHERE ce.event_id = $1
+		  AND ce.is_cancelled = false
+		  AND ce.payment_status = 'paid'
+		  AND u.id = ANY($2)
+		ORDER BY u.last_name, u.first_name
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, eventID, customerIDs)
+	if err != nil {
+		log.Printf("[EVENT-NOTIFICATION] Error querying specific customers: %v", err)
+		return nil, errLib.New("Failed to get customers", http.StatusInternalServerError)
+	}
+	defer rows.Close()
+
+	var customers []EventCustomer
+	for rows.Next() {
+		var c EventCustomer
+		var emailNull sql.NullString
+		if err := rows.Scan(&c.ID, &c.FirstName, &c.LastName, &emailNull, &c.HasPushToken); err != nil {
+			log.Printf("[EVENT-NOTIFICATION] Error scanning customer row: %v", err)
+			continue
+		}
+		if emailNull.Valid {
+			c.Email = emailNull.String
+		}
+		customers = append(customers, c)
+	}
+
+	return customers, nil
+}
+
+// GetEventEnrollmentCount returns the count of enrolled customers for an event
+func (s *EventNotificationService) GetEventEnrollmentCount(ctx context.Context, eventID uuid.UUID) (int, *errLib.CommonError) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM events.customer_enrollment
+		WHERE event_id = $1 AND is_cancelled = false AND payment_status = 'paid'
+	`, eventID).Scan(&count)
+
+	if err != nil {
+		return 0, errLib.New("Failed to get enrollment count", http.StatusInternalServerError)
+	}
+	return count, nil
+}
+
+// CheckCoachHasAccessToEvent verifies if a coach has access to the event
+func (s *EventNotificationService) CheckCoachHasAccessToEvent(ctx context.Context, eventID, staffID uuid.UUID) (bool, *errLib.CommonError) {
+	var hasAccess bool
+	err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM events.events e
+			LEFT JOIN athletic.teams t ON e.team_id = t.id
+			LEFT JOIN events.staff es ON es.event_id = e.id
+			WHERE e.id = $1
+			  AND (
+				t.coach_id = $2
+				OR es.staff_id = $2
+			  )
+		)
+	`, eventID, staffID).Scan(&hasAccess)
+
+	if err != nil {
+		return false, errLib.New("Failed to check coach access", http.StatusInternalServerError)
+	}
+	return hasAccess, nil
+}
+
+// GetEventDetails retrieves event details for including in notifications
+func (s *EventNotificationService) GetEventDetails(ctx context.Context, eventID uuid.UUID) (name string, startAt time.Time, locationName string, err *errLib.CommonError) {
+	query := `
+		SELECT
+			COALESCE(p.name, t.name, 'Event') AS event_name,
+			e.start_at,
+			COALESCE(l.name, '') AS location_name
+		FROM events.events e
+		LEFT JOIN program.programs p ON e.program_id = p.id
+		LEFT JOIN athletic.teams t ON e.team_id = t.id
+		LEFT JOIN location.locations l ON e.location_id = l.id
+		WHERE e.id = $1
+	`
+
+	var eventName, locName string
+	var start time.Time
+	dbErr := s.db.QueryRowContext(ctx, query, eventID).Scan(&eventName, &start, &locName)
+	if dbErr != nil {
+		if dbErr == sql.ErrNoRows {
+			return "", time.Time{}, "", errLib.New("Event not found", http.StatusNotFound)
+		}
+		return "", time.Time{}, "", errLib.New("Failed to get event details", http.StatusInternalServerError)
+	}
+
+	return eventName, start, locName, nil
+}
+
+// SendNotification sends notifications to event attendees
+func (s *EventNotificationService) SendNotification(
+	ctx context.Context,
+	eventID uuid.UUID,
+	senderID uuid.UUID,
+	request dto.SendNotificationRequestDto,
+) (*NotificationResult, *errLib.CommonError) {
+	// Get target customers
+	var customers []EventCustomer
+	var err *errLib.CommonError
+
+	if len(request.CustomerIDs) > 0 {
+		customers, err = s.GetEventCustomersByIDs(ctx, eventID, request.CustomerIDs)
+	} else {
+		customers, err = s.GetEventCustomers(ctx, eventID)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(customers) == 0 {
+		return nil, errLib.New("No customers found to notify", http.StatusBadRequest)
+	}
+
+	result := &NotificationResult{
+		RecipientCount: len(customers),
+	}
+
+	// Get event details if needed
+	var eventDetails string
+	if request.IncludeEventDetails {
+		eventName, startAt, locationName, _ := s.GetEventDetails(ctx, eventID)
+		if eventName != "" {
+			eventDetails = fmt.Sprintf("\n\nEvent: %s\nDate: %s\nLocation: %s",
+				eventName,
+				startAt.Format("Monday, January 2, 2006 at 3:04 PM"),
+				locationName,
+			)
+		}
+	}
+
+	message := request.Message
+	if eventDetails != "" {
+		message += eventDetails
+	}
+
+	// Send emails if channel is email or both
+	if request.Channel == string(dto.ChannelEmail) || request.Channel == string(dto.ChannelBoth) {
+		emailSuccess, emailFailed := s.sendEmails(customers, request.Subject, message)
+		result.EmailSent = emailSuccess
+		result.EmailFailed = emailFailed
+	}
+
+	// Send push notifications if channel is push or both
+	if request.Channel == string(dto.ChannelPush) || request.Channel == string(dto.ChannelBoth) {
+		pushSuccess, pushFailed := s.sendPushNotifications(ctx, eventID, request.Subject, request.Message)
+		result.PushSent = pushSuccess
+		result.PushFailed = pushFailed
+	}
+
+	// Record notification in history
+	notificationID, recordErr := s.recordNotificationHistory(ctx, eventID, senderID, request, result)
+	if recordErr != nil {
+		log.Printf("[EVENT-NOTIFICATION] Failed to record notification history: %v", recordErr)
+		// Don't fail the whole operation, just log
+	}
+	result.NotificationID = notificationID
+
+	log.Printf("[EVENT-NOTIFICATION] Notification sent for event %s: recipients=%d, email_sent=%d, email_failed=%d, push_sent=%d, push_failed=%d",
+		eventID, result.RecipientCount, result.EmailSent, result.EmailFailed, result.PushSent, result.PushFailed)
+
+	return result, nil
+}
+
+// sendEmails sends emails to customers
+func (s *EventNotificationService) sendEmails(customers []EventCustomer, subject, message string) (success int, failed int) {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for _, customer := range customers {
+		if customer.Email == "" {
+			mu.Lock()
+			failed++
+			mu.Unlock()
+			continue
+		}
+
+		wg.Add(1)
+		go func(c EventCustomer) {
+			defer wg.Done()
+
+			body := email.EventNotificationBody(c.FirstName, subject, message)
+			if err := email.SendEmail(c.Email, subject, body); err != nil {
+				log.Printf("[EVENT-NOTIFICATION] Failed to send email to %s: %v", c.Email, err.Message)
+				mu.Lock()
+				failed++
+				mu.Unlock()
+			} else {
+				mu.Lock()
+				success++
+				mu.Unlock()
+			}
+		}(customer)
+	}
+
+	wg.Wait()
+	return success, failed
+}
+
+// sendPushNotifications sends push notifications to customers enrolled in the event
+func (s *EventNotificationService) sendPushNotifications(ctx context.Context, eventID uuid.UUID, title, body string) (success int, failed int) {
+	// Get push tokens for enrolled customers
+	query := `
+		SELECT
+			pt.expo_push_token
+		FROM events.customer_enrollment ce
+		JOIN notifications.push_tokens pt ON pt.user_id = ce.customer_id
+		WHERE ce.event_id = $1
+		  AND ce.is_cancelled = false
+		  AND ce.payment_status = 'paid'
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, eventID)
+	if err != nil {
+		log.Printf("[EVENT-NOTIFICATION] Error getting push tokens: %v", err)
+		return 0, 0
+	}
+	defer rows.Close()
+
+	var tokens []string
+	for rows.Next() {
+		var token string
+		if err := rows.Scan(&token); err != nil {
+			continue
+		}
+		tokens = append(tokens, token)
+	}
+
+	if len(tokens) == 0 {
+		return 0, 0
+	}
+
+	// Prepare Expo messages
+	type ExpoMessage struct {
+		To    string `json:"to"`
+		Title string `json:"title"`
+		Body  string `json:"body"`
+		Sound string `json:"sound"`
+	}
+
+	messages := make([]ExpoMessage, len(tokens))
+	for i, token := range tokens {
+		messages[i] = ExpoMessage{
+			To:    token,
+			Title: title,
+			Body:  body,
+			Sound: "default",
+		}
+	}
+
+	// Send to Expo
+	jsonData, err := json.Marshal(messages)
+	if err != nil {
+		log.Printf("[EVENT-NOTIFICATION] Failed to marshal push messages: %v", err)
+		return 0, len(tokens)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest("POST", "https://exp.host/--/api/v2/push/send", bytes.NewBuffer(jsonData))
+	if err != nil {
+		log.Printf("[EVENT-NOTIFICATION] Failed to create Expo request: %v", err)
+		return 0, len(tokens)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("[EVENT-NOTIFICATION] Failed to send to Expo: %v", err)
+		return 0, len(tokens)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("[EVENT-NOTIFICATION] Expo returned status %d", resp.StatusCode)
+		return 0, len(tokens)
+	}
+
+	// Parse response to count successes/failures
+	type ExpoResult struct {
+		Status string `json:"status"`
+	}
+	type ExpoResponse struct {
+		Data []ExpoResult `json:"data"`
+	}
+
+	var expoResp ExpoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&expoResp); err != nil {
+		log.Printf("[EVENT-NOTIFICATION] Failed to decode Expo response: %v", err)
+		return len(tokens), 0 // Assume success if we got 200
+	}
+
+	for _, result := range expoResp.Data {
+		if result.Status == "ok" {
+			success++
+		} else {
+			failed++
+		}
+	}
+
+	return success, failed
+}
+
+// recordNotificationHistory saves the notification to history
+func (s *EventNotificationService) recordNotificationHistory(
+	ctx context.Context,
+	eventID uuid.UUID,
+	senderID uuid.UUID,
+	request dto.SendNotificationRequestDto,
+	result *NotificationResult,
+) (uuid.UUID, error) {
+	var id uuid.UUID
+	err := s.db.QueryRowContext(ctx, `
+		INSERT INTO events.notification_history (
+			event_id, sent_by, channel, subject, message, include_event_details,
+			recipient_count, email_success_count, email_failure_count, push_success_count, push_failure_count
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING id
+	`, eventID, senderID, request.Channel, request.Subject, request.Message, request.IncludeEventDetails,
+		result.RecipientCount, result.EmailSent, result.EmailFailed, result.PushSent, result.PushFailed).Scan(&id)
+
+	return id, err
+}
+
+// GetNotificationHistory retrieves notification history for an event
+func (s *EventNotificationService) GetNotificationHistory(ctx context.Context, eventID uuid.UUID) ([]dto.NotificationHistoryDto, *errLib.CommonError) {
+	query := `
+		SELECT
+			nh.id,
+			nh.event_id,
+			nh.sent_by,
+			u.first_name || ' ' || u.last_name AS sent_by_name,
+			nh.channel,
+			nh.subject,
+			nh.message,
+			nh.include_event_details,
+			nh.recipient_count,
+			nh.email_success_count,
+			nh.email_failure_count,
+			nh.push_success_count,
+			nh.push_failure_count,
+			nh.created_at
+		FROM events.notification_history nh
+		JOIN users.users u ON nh.sent_by = u.id
+		WHERE nh.event_id = $1
+		ORDER BY nh.created_at DESC
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, eventID)
+	if err != nil {
+		return nil, errLib.New("Failed to get notification history", http.StatusInternalServerError)
+	}
+	defer rows.Close()
+
+	var history []dto.NotificationHistoryDto
+	for rows.Next() {
+		var h dto.NotificationHistoryDto
+		var subject sql.NullString
+		var createdAt time.Time
+
+		if err := rows.Scan(
+			&h.ID, &h.EventID, &h.SentBy, &h.SentByName, &h.Channel,
+			&subject, &h.Message, &h.IncludeEventDetails, &h.RecipientCount,
+			&h.EmailSuccessCount, &h.EmailFailureCount, &h.PushSuccessCount, &h.PushFailureCount,
+			&createdAt,
+		); err != nil {
+			log.Printf("[EVENT-NOTIFICATION] Error scanning history row: %v", err)
+			continue
+		}
+
+		if subject.Valid {
+			h.Subject = subject.String
+		}
+		h.CreatedAt = createdAt.Format(time.RFC3339)
+		history = append(history, h)
+	}
+
+	return history, nil
+}

--- a/utils/email/template.go
+++ b/utils/email/template.go
@@ -434,3 +434,38 @@ func PaymentFailedReminderBody(firstName, membershipPlan, updatePaymentURL strin
 		</html>
 	`, firstName, membershipPlan, daysUntilSuspension, updatePaymentURL)
 }
+
+func EventNotificationBody(firstName, subject, message string) string {
+	return fmt.Sprintf(`
+		<!DOCTYPE html>
+		<html>
+		<head>
+			<style>
+				body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+				.container { max-width: 600px; margin: 0 auto; padding: 20px; }
+				.header { background-color: #007bff; color: white; padding: 20px; text-align: center; border-radius: 5px 5px 0 0; }
+				.content { background-color: #f9f9f9; padding: 30px; border-radius: 0 0 5px 5px; }
+				.message-box { background-color: white; border: 1px solid #ddd; padding: 20px; margin: 20px 0; border-radius: 5px; white-space: pre-wrap; }
+				.footer { margin-top: 20px; padding-top: 20px; border-top: 1px solid #ddd; font-size: 12px; color: #666; }
+			</style>
+		</head>
+		<body>
+			<div class="container">
+				<div class="header">
+					<h1>%s</h1>
+				</div>
+				<div class="content">
+					<p>Hi %s,</p>
+
+					<div class="message-box">%s</div>
+
+					<div class="footer">
+						<p>Thanks,<br>The Rise Team</p>
+						<p>This is an automated message from Rise Sports Complex.</p>
+					</div>
+				</div>
+			</div>
+		</body>
+		</html>
+	`, subject, firstName, message)
+}


### PR DESCRIPTION
   # ✨ Changes Made

   - Add POST /events/{event_id}/notifications endpoint to send email/push notifications to event attendees
   - Add GET /events/{event_id}/notifications endpoint to view notification history
   - Add GET /events/{event_id}/customers endpoint to get enrolled customers for notification preview
   - Add notification_history table migration for audit trail
   - Add coach authorization check (coaches can only notify their own events)

   ---

   # 🧠 Reason for Changes

   Allow admins and coaches to communicate with event attendees via email and/or push notifications directly from the
    system, with full history tracking for audit purposes.

   ---

   # 🧪 Testing Performed

   - [ ] Frontend tested locally (`npm run dev`)
   - [ ] Mobile App tested via Expo / emulator
   - [x] Backend APIs tested via Postman
   - [ ] No console errors (Frontend)
   - [x] No server errors (Backend)
   - [ ] Mobile app builds successfully (if applicable)