### PR TITLE
fixed customer endpoint

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -5,4 +5,4 @@ bin = "bin/api.exe"
 poll = true  # Enable polling
 
 [watch]
-dirs = ["cmd", "internal, docs"]  # Directories to watch
+dirs = ["cmd", "internal", "docs"]  # Directories to watch


### PR DESCRIPTION
  ✨ Changes Made

  - Fixed route conflict where r.Route("/{event_id}/customers", ...) subrouter was overriding the standalone GET handler
  - Moved GET customers handler inside RegisterEventCustomerRoutes so Chi subrouter handles both GET / and DELETE /{customer_id}
  - Fixed .air.toml directory watch config - "internal, docs" was incorrectly a single string instead of two separate entries

  ---
  🧠 Reason for Changes

  The GET /events/{event_id}/customers endpoint was returning 404 while POST /events/{event_id}/notifications worked fine. This was because Chi's r.Route() creates a subrouter that captures all requests for a path prefix, overriding any standalone handlers registered for the same pattern.

  ---
  🧪 Testing Performed

  - Frontend tested locally (npm run dev)
  - Mobile App tested via Expo / emulator
  - Backend APIs tested via Postman
  - No console errors (Frontend)
  - No server errors (Backend)
  - Mobile app builds successfully (if applicable)

  Endpoints verified locally:
  - GET /events/{event_id}/customers → Returns enrolled customers ✅
  - GET /events/{event_id}/notifications → Returns notification history ✅
  - POST /events/{event_id}/notifications → Sends notifications ✅