### PR TITLE
Add credit refund capability when removing customers from events

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -402,8 +402,8 @@ func RegisterEventCustomerRoutes(container *di.Container, notificationHandler *e
 	return func(r chi.Router) {
 		// GET / - List enrolled customers (for notification preview)
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin, contextUtils.RoleSuperAdmin, contextUtils.RoleIT, contextUtils.RoleCoach, contextUtils.RoleReceptionist)).Get("/", notificationHandler.GetEventCustomers)
-		// DELETE /{customer_id} - Remove customer from event
-		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin)).Delete("/{customer_id}", h.RemoveCustomerFromEvent)
+		// DELETE /{customer_id} - Remove customer from event (with optional credit refund)
+		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin, contextUtils.RoleSuperAdmin, contextUtils.RoleIT)).Delete("/{customer_id}", h.RemoveCustomerFromEvent)
 	}
 }
 
@@ -638,6 +638,9 @@ func RegisterAdminRoutes(container *di.Container) func(chi.Router) {
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin, contextUtils.RoleSuperAdmin, contextUtils.RoleIT)).Post("/customers/{id}/credits/deduct", creditHandler.DeductCustomerCredits)
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin, contextUtils.RoleSuperAdmin, contextUtils.RoleIT, contextUtils.RoleReceptionist)).Get("/events/{id}/credit-transactions", creditHandler.GetEventCreditTransactions)
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin, contextUtils.RoleSuperAdmin, contextUtils.RoleIT)).Put("/events/{id}/credit-cost", creditHandler.UpdateEventCreditCost)
+
+		// Credit refund audit logs - admin only
+		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin, contextUtils.RoleSuperAdmin, contextUtils.RoleIT)).Get("/credit-refund-logs", creditHandler.GetCreditRefundLogs)
 
 		// Firebase cleanup - IT and SuperAdmin only (sensitive operation)
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleSuperAdmin, contextUtils.RoleIT)).Post("/firebase/cleanup", firebaseCleanupHandler.CleanupOrphanedFirebaseUsers)

--- a/db/migrations/20260107180000_credit_refund_audit_log.sql
+++ b/db/migrations/20260107180000_credit_refund_audit_log.sql
@@ -1,0 +1,51 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Audit log for credit refunds when admins remove customers from events
+-- Captures full event context snapshot for compliance and auditing
+CREATE TABLE IF NOT EXISTS audit.credit_refund_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    customer_id UUID NOT NULL REFERENCES users.users(id) ON DELETE CASCADE,
+    event_id UUID REFERENCES events.events(id) ON DELETE SET NULL,
+    performed_by UUID NOT NULL REFERENCES users.users(id) ON DELETE CASCADE,
+
+    -- Refund details
+    credits_refunded INTEGER NOT NULL,
+
+    -- Event snapshot (preserved if event is later deleted)
+    event_name TEXT,
+    event_start_at TIMESTAMPTZ,
+    program_name TEXT,
+    location_name TEXT,
+
+    -- Admin context
+    staff_role VARCHAR(50),
+    reason TEXT,
+    ip_address TEXT,
+
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for efficient querying
+CREATE INDEX idx_credit_refund_logs_customer ON audit.credit_refund_logs(customer_id);
+CREATE INDEX idx_credit_refund_logs_event ON audit.credit_refund_logs(event_id);
+CREATE INDEX idx_credit_refund_logs_performed_by ON audit.credit_refund_logs(performed_by);
+CREATE INDEX idx_credit_refund_logs_created_at ON audit.credit_refund_logs(created_at DESC);
+
+COMMENT ON TABLE audit.credit_refund_logs IS 'Audit trail for credit refunds when customers are removed from events';
+COMMENT ON COLUMN audit.credit_refund_logs.credits_refunded IS 'Number of credits refunded to customer';
+COMMENT ON COLUMN audit.credit_refund_logs.event_name IS 'Snapshot of event name at time of refund';
+COMMENT ON COLUMN audit.credit_refund_logs.staff_role IS 'Role of admin who processed the refund';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP INDEX IF EXISTS idx_credit_refund_logs_customer;
+DROP INDEX IF EXISTS idx_credit_refund_logs_event;
+DROP INDEX IF EXISTS idx_credit_refund_logs_performed_by;
+DROP INDEX IF EXISTS idx_credit_refund_logs_created_at;
+DROP TABLE IF EXISTS audit.credit_refund_logs;
+
+-- +goose StatementEnd

--- a/internal/domains/enrollment/handler/customer_enrollment_handler.go
+++ b/internal/domains/enrollment/handler/customer_enrollment_handler.go
@@ -1,53 +1,173 @@
 package enrollment
 
 import (
+	"database/sql"
+	"encoding/json"
+	"log"
 	"net/http"
 
 	"api/internal/di"
 	enrollmentService "api/internal/domains/enrollment/service"
+	userServices "api/internal/domains/user/services"
+	"api/internal/middlewares"
 	responseHandlers "api/internal/libs/responses"
+	contextUtils "api/utils/context"
+
+	"github.com/google/uuid"
 )
 
+// RemoveCustomerRequest represents the optional request body for removing a customer
+type RemoveCustomerRequest struct {
+	RefundCredits bool   `json:"refund_credits"`
+	Reason        string `json:"reason,omitempty"`
+}
+
+// RemoveCustomerResponse represents the response for removing a customer
+type RemoveCustomerResponse struct {
+	Message string        `json:"message"`
+	Refund  *RefundInfo   `json:"refund,omitempty"`
+}
+
+// RefundInfo holds information about a credit refund
+type RefundInfo struct {
+	Processed       bool  `json:"processed"`
+	CreditsRefunded int32 `json:"credits_refunded"`
+}
+
 type CustomerEnrollmentHandler struct {
-	Service *enrollmentService.CustomerEnrollmentService
+	Service       *enrollmentService.CustomerEnrollmentService
+	CreditService *userServices.CustomerCreditService
+	db            *sql.DB
 }
 
 func NewCustomerEnrollmentHandler(container *di.Container) *CustomerEnrollmentHandler {
-	return &CustomerEnrollmentHandler{Service: enrollmentService.NewCustomerEnrollmentService(container)}
+	return &CustomerEnrollmentHandler{
+		Service:       enrollmentService.NewCustomerEnrollmentService(container),
+		CreditService: userServices.NewCustomerCreditService(container),
+		db:            container.DB,
+	}
 }
 
-// RemoveCustomerFromEvent removes a customer completely from an event.
+// RemoveCustomerFromEvent removes a customer from an event with optional credit refund.
 // @Summary Remove a customer from an event
-// @Description Completely removes a customer's enrollment from an event (deletes the record).
+// @Description Removes a customer's enrollment from an event. Optionally refunds credits if the customer paid with credits.
 // @Tags event_enrollment
 // @Accept json
 // @Produce json
 // @Param event_id path string true "Event ID" Format(uuid)
 // @Param customer_id path string true "Customer ID" Format(uuid)
-// @Success 200 {object} map[string]interface{} "Customer successfully removed from event"
+// @Param body body RemoveCustomerRequest false "Optional refund options"
+// @Success 200 {object} RemoveCustomerResponse "Customer successfully removed from event"
 // @Failure 400 {object} map[string]interface{} "Bad Request: Invalid input"
 // @Failure 404 {object} map[string]interface{} "Not Found: Enrollment not found"
 // @Failure 500 {object} map[string]interface{} "Internal Server Error"
 // @Security Bearer
 // @Router /events/{event_id}/customers/{customer_id} [delete]
 func (h *CustomerEnrollmentHandler) RemoveCustomerFromEvent(w http.ResponseWriter, r *http.Request) {
-
-	eventId, err := parseUUIDParam(r, "event_id")
+	eventID, err := parseUUIDParam(r, "event_id")
 	if err != nil {
 		responseHandlers.RespondWithError(w, err)
 		return
 	}
 
-	customerId, err := parseUUIDParam(r, "customer_id")
+	customerID, err := parseUUIDParam(r, "customer_id")
 	if err != nil {
 		responseHandlers.RespondWithError(w, err)
 		return
 	}
 
-	if err = h.Service.RemoveCustomerFromEvent(r.Context(), eventId, customerId); err != nil {
+	// Parse optional request body for refund options
+	var request RemoveCustomerRequest
+	if r.Body != nil && r.ContentLength > 0 {
+		if decodeErr := json.NewDecoder(r.Body).Decode(&request); decodeErr != nil {
+			log.Printf("[REMOVE-CUSTOMER] Failed to decode request body: %v", decodeErr)
+			// Continue without refund options if body is invalid
+		}
+	}
+
+	// Prepare response
+	response := RemoveCustomerResponse{
+		Message: "Customer removed from event",
+		Refund: &RefundInfo{
+			Processed:       false,
+			CreditsRefunded: 0,
+		},
+	}
+
+	// Process refund if requested
+	if request.RefundCredits {
+		// Get performer info from context
+		performerID, idErr := contextUtils.GetUserID(r.Context())
+		if idErr != nil {
+			log.Printf("[REMOVE-CUSTOMER] Failed to get performer ID: %v", idErr)
+		} else {
+			// Get role for audit
+			role, _ := contextUtils.GetUserRole(r.Context())
+			staffRole := string(role)
+
+			// Get IP address for audit
+			ipAddress := middlewares.GetRealIP(r)
+
+			// Get event details for audit snapshot
+			eventSnapshot := h.getEventSnapshot(eventID)
+
+			// Process refund
+			refundResult, refundErr := h.CreditService.RefundCreditsWithAudit(
+				r.Context(),
+				eventID,
+				customerID,
+				performerID,
+				staffRole,
+				request.Reason,
+				ipAddress,
+				eventSnapshot,
+			)
+			if refundErr != nil {
+				log.Printf("[REMOVE-CUSTOMER] Credit refund failed: %v", refundErr)
+				// Continue with removal even if refund fails
+			} else if refundResult != nil {
+				response.Refund.Processed = refundResult.Processed
+				response.Refund.CreditsRefunded = refundResult.CreditsRefunded
+			}
+		}
+	}
+
+	// Remove customer from event
+	if err = h.Service.RemoveCustomerFromEvent(r.Context(), eventID, customerID); err != nil {
 		responseHandlers.RespondWithError(w, err)
 		return
 	}
 
-	responseHandlers.RespondWithSuccess(w, nil, http.StatusOK)
+	responseHandlers.RespondWithSuccess(w, response, http.StatusOK)
+}
+
+// getEventSnapshot retrieves event details for audit logging
+func (h *CustomerEnrollmentHandler) getEventSnapshot(eventID uuid.UUID) userServices.EventSnapshot {
+	snapshot := userServices.EventSnapshot{}
+
+	query := `
+		SELECT
+			COALESCE(p.name, t.name, 'Event') AS event_name,
+			e.start_at,
+			COALESCE(p.name, '') AS program_name,
+			COALESCE(l.name, '') AS location_name
+		FROM events.events e
+		LEFT JOIN program.programs p ON e.program_id = p.id
+		LEFT JOIN athletic.teams t ON e.team_id = t.id
+		LEFT JOIN location.locations l ON e.location_id = l.id
+		WHERE e.id = $1
+	`
+
+	var eventName, programName, locationName string
+	err := h.db.QueryRow(query, eventID).Scan(&eventName, &snapshot.StartAt, &programName, &locationName)
+	if err != nil {
+		log.Printf("[REMOVE-CUSTOMER] Failed to get event details for audit: %v", err)
+		return snapshot
+	}
+
+	snapshot.Name = eventName
+	snapshot.ProgramName = programName
+	snapshot.LocationName = locationName
+
+	return snapshot
 }

--- a/internal/domains/user/persistence/sqlc/generated/models.go
+++ b/internal/domains/user/persistence/sqlc/generated/models.go
@@ -549,6 +549,26 @@ type AthleticTeam struct {
 	IsExternal bool `json:"is_external"`
 }
 
+// Audit trail for credit refunds when customers are removed from events
+type AuditCreditRefundLog struct {
+	ID          uuid.UUID     `json:"id"`
+	CustomerID  uuid.UUID     `json:"customer_id"`
+	EventID     uuid.NullUUID `json:"event_id"`
+	PerformedBy uuid.UUID     `json:"performed_by"`
+	// Number of credits refunded to customer
+	CreditsRefunded int32 `json:"credits_refunded"`
+	// Snapshot of event name at time of refund
+	EventName    sql.NullString `json:"event_name"`
+	EventStartAt sql.NullTime   `json:"event_start_at"`
+	ProgramName  sql.NullString `json:"program_name"`
+	LocationName sql.NullString `json:"location_name"`
+	// Role of admin who processed the refund
+	StaffRole sql.NullString `json:"staff_role"`
+	Reason    sql.NullString `json:"reason"`
+	IpAddress sql.NullString `json:"ip_address"`
+	CreatedAt sql.NullTime   `json:"created_at"`
+}
+
 type AuditOutbox struct {
 	ID           uuid.UUID        `json:"id"`
 	SqlStatement string           `json:"sql_statement"`
@@ -631,6 +651,25 @@ type EventsEventMembershipAccess struct {
 	EventID          uuid.UUID    `json:"event_id"`
 	MembershipPlanID uuid.UUID    `json:"membership_plan_id"`
 	CreatedAt        sql.NullTime `json:"created_at"`
+}
+
+// Tracks notifications sent to event attendees
+type EventsNotificationHistory struct {
+	ID      uuid.UUID `json:"id"`
+	EventID uuid.UUID `json:"event_id"`
+	SentBy  uuid.UUID `json:"sent_by"`
+	// Notification channel: email, push, or both
+	Channel string         `json:"channel"`
+	Subject sql.NullString `json:"subject"`
+	Message string         `json:"message"`
+	// Whether event details were automatically included in the message
+	IncludeEventDetails bool      `json:"include_event_details"`
+	RecipientCount      int32     `json:"recipient_count"`
+	EmailSuccessCount   int32     `json:"email_success_count"`
+	EmailFailureCount   int32     `json:"email_failure_count"`
+	PushSuccessCount    int32     `json:"push_success_count"`
+	PushFailureCount    int32     `json:"push_failure_count"`
+	CreatedAt           time.Time `json:"created_at"`
 }
 
 type EventsStaff struct {
@@ -827,6 +866,12 @@ type PaymentsPaymentTransaction struct {
 	RefundedAt     sql.NullTime          `json:"refunded_at"`
 	CreatedAt      time.Time             `json:"created_at"`
 	UpdatedAt      time.Time             `json:"updated_at"`
+	// Stripe receipt URL for one-time payments (events, programs, credit packages)
+	ReceiptUrl sql.NullString `json:"receipt_url"`
+	// Stripe hosted invoice URL for subscription payments
+	InvoiceUrl sql.NullString `json:"invoice_url"`
+	// Stripe invoice PDF download URL for subscription payments
+	InvoicePdfUrl sql.NullString `json:"invoice_pdf_url"`
 }
 
 type PlaygroundSession struct {


### PR DESCRIPTION
  # ✨ Changes Made

  - Add optional `refund_credits` flag to `DELETE /events/{event_id}/customers/{customer_id}` endpoint
  - Create `audit.credit_refund_logs` table for tracking all credit refunds with full event context
  - Add `GET /admin/credit-refund-logs` endpoint to view refund audit trail (filterable by customer/event)
  - Implement `RefundCreditsWithAudit` service method that refunds credits and logs to audit table
  - Update router permissions: Admin, SuperAdmin, IT can all remove customers and process refunds

  ---

  # 🧠 Reason for Changes

  When admins remove customers from events, they need the ability to optionally refund credits if the customer paid with credits. A full audit trail is required for compliance, capturing event snapshot data (name, program, location, start time) so records persist even if the event is later deleted.

  ---

  # 🧪 Testing Performed

  - [ ] Frontend tested locally (`npm run dev`)
  - [ ] Mobile App tested via Expo / emulator
  - [x] Backend APIs tested via Postman
  - [ ] No console errors (Frontend)
  - [x] No server errors (Backend)
  - [ ] Mobile app builds successfully (if applicable)

  **API Tests Performed:**
  - Tested remove customer without refund → `processed: false`
  - Tested remove customer with refund → `processed: true, credits_refunded: 2`
  - Verified credits restored to customer account
  - Verified audit log created with event snapshot
  - Tested `GET /admin/credit-refund-logs` returns audit data

  ---

  # 📸 Screenshots or Screen Recording (Optional)

  **Remove with refund response:**
  ```json
  {"message":"Customer removed from event","refund":{"processed":true,"credits_refunded":2}}

  Audit log response:
  {"customer_name":"AJ Go","event_name":"Course","credits_refunded":2,"performed_by_name":"test admin","staff_role":"SUPERADMIN","reason":"Customer requested removal"}

  ---
  🔗 Related Trello Task

  ---
  🗒️ Notes for Reviewer (Optional)

  - Refunded credits do NOT affect weekly usage tracking (they're "bonus" credits back)
  - Event snapshot is preserved in audit log even if event is deleted later
  - No approval code required - all admins can freely process refunds