### PR TITLE
Add auto-notification for event/game/practice updates

### DIFF
--- a/internal/domains/event/dto/requests.go
+++ b/internal/domains/event/dto/requests.go
@@ -45,8 +45,9 @@ type EventRequestDto struct {
 	CreditCost                *int32      `json:"credit_cost" validate:"omitempty,gte=0" example:"5"`
 	RegistrationRequired      *bool       `json:"registration_required" example:"true"` // Defaults to true if not provided
 	// Fields for Stripe auto-creation (when PriceID is not provided)
-	UnitAmount *int64 `json:"unit_amount" example:"2500"` // Price in cents (e.g., 2500 = $25.00)
-	Currency   string `json:"currency" example:"cad"`     // "cad" or "usd", defaults to "cad"
+	UnitAmount       *int64 `json:"unit_amount" example:"2500"`        // Price in cents (e.g., 2500 = $25.00)
+	Currency         string `json:"currency" example:"cad"`           // "cad" or "usd", defaults to "cad"
+	SkipNotification *bool  `json:"skip_notification" example:"false"` // Skip auto-notification on update (for minor changes)
 }
 
 type DeleteRequestDto struct {
@@ -256,9 +257,16 @@ func (dto EventRequestDto) ToUpdateEventValues(idStr string, updater uuid.UUID) 
 		registrationRequired = *dto.RegistrationRequired
 	}
 
+	// Default skip_notification to false if not provided
+	skipNotification := false
+	if dto.SkipNotification != nil {
+		skipNotification = *dto.SkipNotification
+	}
+
 	v := values.UpdateEventValues{
-		ID:        id,
-		UpdatedBy: updater,
+		ID:               id,
+		UpdatedBy:        updater,
+		SkipNotification: skipNotification,
 		EventDetails: values.EventDetails{
 			StartAt:                   startAt,
 			EndAt:                     endAt,

--- a/internal/domains/event/values/change_detection.go
+++ b/internal/domains/event/values/change_detection.go
@@ -1,0 +1,45 @@
+package event
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EventChanges tracks what changed between an existing event and an update
+type EventChanges struct {
+	StartTimeChanged bool
+	EndTimeChanged   bool
+	LocationChanged  bool
+
+	// Store old/new values for message building
+	OldStartAt      time.Time
+	NewStartAt      time.Time
+	OldEndAt        time.Time
+	NewEndAt        time.Time
+	OldLocationID   uuid.UUID
+	NewLocationID   uuid.UUID
+	OldLocationName string
+	NewLocationName string
+}
+
+// HasSignificantChanges returns true if any key details changed that warrant notification
+func (c EventChanges) HasSignificantChanges() bool {
+	return c.StartTimeChanged || c.EndTimeChanged || c.LocationChanged
+}
+
+// DetectEventChanges compares an existing event with new update values to identify changes
+func DetectEventChanges(existing ReadEventValues, new UpdateEventValues) EventChanges {
+	return EventChanges{
+		StartTimeChanged: !existing.StartAt.Equal(new.StartAt),
+		EndTimeChanged:   !existing.EndAt.Equal(new.EndAt),
+		LocationChanged:  existing.Location.ID != new.LocationID,
+		OldStartAt:       existing.StartAt,
+		NewStartAt:       new.StartAt,
+		OldEndAt:         existing.EndAt,
+		NewEndAt:         new.EndAt,
+		OldLocationID:    existing.Location.ID,
+		NewLocationID:    new.LocationID,
+		OldLocationName:  existing.Location.Name,
+	}
+}

--- a/internal/domains/event/values/event.go
+++ b/internal/domains/event/values/event.go
@@ -30,8 +30,9 @@ type CreateEventValues struct {
 }
 
 type UpdateEventValues struct {
-	ID        uuid.UUID
-	UpdatedBy uuid.UUID
+	ID               uuid.UUID
+	UpdatedBy        uuid.UUID
+	SkipNotification bool // Skip auto-notification on update (for minor changes)
 	EventDetails
 }
 

--- a/internal/domains/game/dto/requests.go
+++ b/internal/domains/game/dto/requests.go
@@ -12,15 +12,16 @@ import (
 // RequestDto represents the expected payload for creating or updating a game.
 // It includes team IDs, scores, time info, location, and game status.
 type RequestDto struct {
-	HomeTeamID uuid.UUID  `json:"home_team_id" validate:"required"`                     // ID of the home team
-	AwayTeamID uuid.UUID  `json:"away_team_id" validate:"required"`                     // ID of the away team
-	HomeScore  *int32     `json:"home_score"`                                           // Optional score for the home team
-	AwayScore  *int32     `json:"away_score"`                                           // Optional score for the away team
-	StartTime  time.Time  `json:"start_time" validate:"required"`                       // Required start time of the game
-	EndTime    *time.Time `json:"end_time"`                                             // Optional end time of the game
-	LocationID uuid.UUID  `json:"location_id" validate:"required"`                      // ID of the location where the game is played
-	CourtID    uuid.UUID  `json:"court_id"`                                             // ID of the court where the game is played
-	Status     string     `json:"status" validate:"oneof=scheduled completed canceled"` // Game status must be one of the allowed values
+	HomeTeamID       uuid.UUID  `json:"home_team_id" validate:"required"`                     // ID of the home team
+	AwayTeamID       uuid.UUID  `json:"away_team_id" validate:"required"`                     // ID of the away team
+	HomeScore        *int32     `json:"home_score"`                                           // Optional score for the home team
+	AwayScore        *int32     `json:"away_score"`                                           // Optional score for the away team
+	StartTime        time.Time  `json:"start_time" validate:"required"`                       // Required start time of the game
+	EndTime          *time.Time `json:"end_time"`                                             // Optional end time of the game
+	LocationID       uuid.UUID  `json:"location_id" validate:"required"`                      // ID of the location where the game is played
+	CourtID          uuid.UUID  `json:"court_id"`                                             // ID of the court where the game is played
+	Status           string     `json:"status" validate:"oneof=scheduled completed canceled"` // Game status must be one of the allowed values
+	SkipNotification *bool      `json:"skip_notification"`                                    // Skip auto-notification on update
 }
 
 // ToCreateGameValue converts a validated RequestDto into a CreateGameValue used in the domain layer.
@@ -72,9 +73,16 @@ func (dto *RequestDto) ToUpdateGameValue(idStr string) (values.UpdateGameValue, 
 		return details, errLib.New("home_team_id and away_team_id must be different", 400)
 	}
 
+	// Default skip_notification to false if not provided
+	skipNotification := false
+	if dto.SkipNotification != nil {
+		skipNotification = *dto.SkipNotification
+	}
+
 	// Construct the UpdateGameValue object using embedded CreateGameValue
 	details = values.UpdateGameValue{
-		ID: id,
+		ID:               id,
+		SkipNotification: skipNotification,
 		CreateGameValue: values.CreateGameValue{
 			HomeTeamID: dto.HomeTeamID,
 			AwayTeamID: dto.AwayTeamID,

--- a/internal/domains/game/values/values.go
+++ b/internal/domains/game/values/values.go
@@ -24,8 +24,9 @@ type CreateGameValue struct {
 // UpdateGameValue represents the data required to update an existing game.
 // It embeds CreateGameValue and adds an ID field for the game being updated.
 type UpdateGameValue struct {
-	ID              uuid.UUID // ID of the game to update
-	CreateGameValue           // Embedded fields for game details
+	ID               uuid.UUID // ID of the game to update
+	SkipNotification bool      // Skip auto-notification on update
+	CreateGameValue            // Embedded fields for game details
 }
 
 // ReadGameValue represents a full game record retrieved from the database.

--- a/internal/domains/practice/dto/requests.go
+++ b/internal/domains/practice/dto/requests.go
@@ -12,13 +12,14 @@ import (
 )
 
 type RequestDto struct {
-	TeamID     uuid.UUID   `json:"team_id" validate:"required"`
-	StartTime  time.Time   `json:"start_time" validate:"required"`
-	EndTime    *time.Time  `json:"end_time"`
-	LocationID uuid.UUID   `json:"location_id" validate:"required"`
-	CourtID    uuid.UUID   `json:"court_id" validate:"required"`
-	Status     string      `json:"status" validate:"oneof=scheduled completed canceled"`
-	BookedBy   *uuid.UUID  `json:"booked_by"`
+	TeamID           uuid.UUID  `json:"team_id" validate:"required"`
+	StartTime        time.Time  `json:"start_time" validate:"required"`
+	EndTime          *time.Time `json:"end_time"`
+	LocationID       uuid.UUID  `json:"location_id" validate:"required"`
+	CourtID          uuid.UUID  `json:"court_id" validate:"required"`
+	Status           string     `json:"status" validate:"oneof=scheduled completed canceled"`
+	BookedBy         *uuid.UUID `json:"booked_by"`
+	SkipNotification *bool      `json:"skip_notification"` // Skip auto-notification on update
 }
 
 func (dto *RequestDto) ToCreateValue() (values.CreatePracticeValue, *errLib.CommonError) {
@@ -44,8 +45,16 @@ func (dto *RequestDto) ToUpdateValue(idStr string) (values.UpdatePracticeValue, 
 	if err = validators.ValidateDto(dto); err != nil {
 		return values.UpdatePracticeValue{}, err
 	}
+
+	// Default skip_notification to false if not provided
+	skipNotification := false
+	if dto.SkipNotification != nil {
+		skipNotification = *dto.SkipNotification
+	}
+
 	return values.UpdatePracticeValue{
-		ID: id,
+		ID:               id,
+		SkipNotification: skipNotification,
 		CreatePracticeValue: values.CreatePracticeValue{
 			TeamID:     dto.TeamID,
 			StartTime:  dto.StartTime,

--- a/internal/domains/practice/values/values.go
+++ b/internal/domains/practice/values/values.go
@@ -17,7 +17,8 @@ type CreatePracticeValue struct {
 }
 
 type UpdatePracticeValue struct {
-	ID uuid.UUID
+	ID               uuid.UUID
+	SkipNotification bool // Skip auto-notification on update
 	CreatePracticeValue
 }
 


### PR DESCRIPTION
   # ✨ Changes Made

   - Added auto-notification when events are updated (time/location changes) - sends email + push to enrolled
   customers
   - Added auto-notification when games are updated - sends push to both home and away teams
   - Added auto-notification when practices are updated - sends push to team members
   - Added `skip_notification` flag to all update endpoints for silent updates

   ---

   # 🧠 Reason for Changes

   Ensures attendees/team members are always aware of schedule changes or location updates. When an admin updates an
   event, game, or practice with key detail changes, users are automatically notified.

   ---

   # 🧪 Testing Performed

   - [ ] Frontend tested locally (`npm run dev`)
   - [ ] Mobile App tested via Expo / emulator
   - [x] Backend APIs tested via Postman
   - [ ] No console errors (Frontend)
   - [x] No server errors (Backend)
   - [ ] Mobile app builds successfully (if applicable)

   ---

   # 🗒️ Notes for Reviewer (Optional)

   - Notifications are sent asynchronously (don't block the API response)
   - Message format shows old vs new values: "Time changed from Monday, Jan 5 at 10:00 AM to 2:00 PM"
   - Use `skip_notification: true` in request body to suppress notifications for minor updates