### PR TITLE
Fixed the weekly credit usage not deducting after refund of credits and mobile response

### DIFF
--- a/internal/domains/user/dto/customer/response.go
+++ b/internal/domains/user/dto/customer/response.go
@@ -21,6 +21,7 @@ type Response struct {
 	EmergencyContactName         *string                `json:"emergency_contact_name,omitempty"`
 	EmergencyContactPhone        *string                `json:"emergency_contact_phone,omitempty"`
 	EmergencyContactRelationship *string                `json:"emergency_contact_relationship,omitempty"`
+	LastMobileLoginAt            *time.Time             `json:"last_mobile_login_at,omitempty"`
 	MembershipInfo               *MembershipResponseDto `json:"membership_info,omitempty"`
 	PhotoURL                     *string                `json:"photo_url,omitempty"`
 	IsArchived                   bool                   `json:"is_archived"`
@@ -50,6 +51,7 @@ func UserReadValueToResponse(customer values.ReadValue) Response {
 		EmergencyContactName:         customer.EmergencyContactName,
 		EmergencyContactPhone:        customer.EmergencyContactPhone,
 		EmergencyContactRelationship: customer.EmergencyContactRelationship,
+		LastMobileLoginAt:            customer.LastMobileLoginAt,
 		IsArchived:                   customer.IsArchived,
 		DeletedAt:                    customer.DeletedAt,
 		ScheduledDeletionAt:          customer.ScheduledDeletionAt,

--- a/internal/domains/user/persistence/repository/customer_repository.go
+++ b/internal/domains/user/persistence/repository/customer_repository.go
@@ -105,6 +105,10 @@ func (r *CustomerRepository) GetCustomers(ctx context.Context, limit, offset int
 			customer.EmergencyContactRelationship = &dbCustomer.EmergencyContactRelationship.String
 		}
 
+		if dbCustomer.LastMobileLoginAt.Valid {
+			customer.LastMobileLoginAt = &dbCustomer.LastMobileLoginAt.Time
+		}
+
 		if dbCustomer.MembershipName.Valid && dbCustomer.MembershipPlanName.Valid && dbCustomer.MembershipStartDate.Valid && dbCustomer.MembershipPlanID.Valid {
 
 			customer.MembershipInfo = &userValues.MembershipReadValue{
@@ -205,6 +209,10 @@ func (r *CustomerRepository) GetCustomer(ctx context.Context, id uuid.UUID, emai
 
 	if dbCustomer.EmergencyContactRelationship.Valid {
 		customer.EmergencyContactRelationship = &dbCustomer.EmergencyContactRelationship.String
+	}
+
+	if dbCustomer.LastMobileLoginAt.Valid {
+		customer.LastMobileLoginAt = &dbCustomer.LastMobileLoginAt.Time
 	}
 
 	if dbCustomer.MembershipName.Valid && dbCustomer.MembershipPlanName.Valid && dbCustomer.MembershipStartDate.Valid && dbCustomer.MembershipPlanID.Valid {

--- a/internal/domains/user/persistence/sqlc/generated/customer.sql.go
+++ b/internal/domains/user/persistence/sqlc/generated/customer.sql.go
@@ -323,7 +323,7 @@ func (q *Queries) GetAthletes(ctx context.Context, arg GetAthletesParams) ([]Get
 }
 
 const getCustomer = `-- name: GetCustomer :one
-SELECT u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship,
+SELECT u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, u.last_mobile_login_at,
        m.name           AS membership_name,
        mp.id            AS membership_plan_id,
        mp.name          AS membership_plan_name,
@@ -391,6 +391,7 @@ type GetCustomerRow struct {
 	EmergencyContactName            sql.NullString `json:"emergency_contact_name"`
 	EmergencyContactPhone           sql.NullString `json:"emergency_contact_phone"`
 	EmergencyContactRelationship    sql.NullString `json:"emergency_contact_relationship"`
+	LastMobileLoginAt               sql.NullTime   `json:"last_mobile_login_at"`
 	MembershipName                  sql.NullString `json:"membership_name"`
 	MembershipPlanID                uuid.NullUUID  `json:"membership_plan_id"`
 	MembershipPlanName              sql.NullString `json:"membership_plan_name"`
@@ -440,6 +441,7 @@ func (q *Queries) GetCustomer(ctx context.Context, arg GetCustomerParams) (GetCu
 		&i.EmergencyContactName,
 		&i.EmergencyContactPhone,
 		&i.EmergencyContactRelationship,
+		&i.LastMobileLoginAt,
 		&i.MembershipName,
 		&i.MembershipPlanID,
 		&i.MembershipPlanName,
@@ -457,7 +459,7 @@ func (q *Queries) GetCustomer(ctx context.Context, arg GetCustomerParams) (GetCu
 }
 
 const getCustomers = `-- name: GetCustomers :many
-SELECT u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship,
+SELECT u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, u.last_mobile_login_at,
        m.name           AS membership_name,
        mp.id            AS membership_plan_id,
        mp.name          AS membership_plan_name,
@@ -534,6 +536,7 @@ type GetCustomersRow struct {
 	EmergencyContactName            sql.NullString `json:"emergency_contact_name"`
 	EmergencyContactPhone           sql.NullString `json:"emergency_contact_phone"`
 	EmergencyContactRelationship    sql.NullString `json:"emergency_contact_relationship"`
+	LastMobileLoginAt               sql.NullTime   `json:"last_mobile_login_at"`
 	MembershipName                  sql.NullString `json:"membership_name"`
 	MembershipPlanID                uuid.NullUUID  `json:"membership_plan_id"`
 	MembershipPlanName              sql.NullString `json:"membership_plan_name"`
@@ -594,6 +597,7 @@ func (q *Queries) GetCustomers(ctx context.Context, arg GetCustomersParams) ([]G
 			&i.EmergencyContactName,
 			&i.EmergencyContactPhone,
 			&i.EmergencyContactRelationship,
+			&i.LastMobileLoginAt,
 			&i.MembershipName,
 			&i.MembershipPlanID,
 			&i.MembershipPlanName,
@@ -779,7 +783,7 @@ func (q *Queries) GetUserSuspendedMemberships(ctx context.Context, userID uuid.U
 }
 
 const listArchivedCustomers = `-- name: ListArchivedCustomers :many
-SELECT u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship
+SELECT u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, u.last_mobile_login_at
 FROM users.users u
 WHERE u.is_archived = TRUE
 LIMIT $2 OFFSET $1
@@ -831,6 +835,7 @@ func (q *Queries) ListArchivedCustomers(ctx context.Context, arg ListArchivedCus
 			&i.EmergencyContactName,
 			&i.EmergencyContactPhone,
 			&i.EmergencyContactRelationship,
+			&i.LastMobileLoginAt,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/domains/user/persistence/sqlc/generated/models.go
+++ b/internal/domains/user/persistence/sqlc/generated/models.go
@@ -1169,6 +1169,7 @@ type UsersUser struct {
 	EmergencyContactName         sql.NullString `json:"emergency_contact_name"`
 	EmergencyContactPhone        sql.NullString `json:"emergency_contact_phone"`
 	EmergencyContactRelationship sql.NullString `json:"emergency_contact_relationship"`
+	LastMobileLoginAt            sql.NullTime   `json:"last_mobile_login_at"`
 }
 
 // Tracks weekly credit consumption per customer for membership limit enforcement

--- a/internal/domains/user/persistence/sqlc/generated/staff.sql.go
+++ b/internal/domains/user/persistence/sqlc/generated/staff.sql.go
@@ -79,7 +79,7 @@ func (q *Queries) GetAvailableStaffRoles(ctx context.Context) ([]StaffStaffRole,
 }
 
 const getStaffs = `-- name: GetStaffs :many
-SELECT s.is_active, u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, sr.role_name, cs.wins, cs.losses, s.photo_url
+SELECT s.is_active, u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, u.last_mobile_login_at, sr.role_name, cs.wins, cs.losses, s.photo_url
 FROM staff.staff s
 JOIN users.users u ON u.id = s.id
 JOIN staff.staff_roles sr ON s.role_id = sr.id
@@ -120,6 +120,7 @@ type GetStaffsRow struct {
 	EmergencyContactName            sql.NullString `json:"emergency_contact_name"`
 	EmergencyContactPhone           sql.NullString `json:"emergency_contact_phone"`
 	EmergencyContactRelationship    sql.NullString `json:"emergency_contact_relationship"`
+	LastMobileLoginAt               sql.NullTime   `json:"last_mobile_login_at"`
 	RoleName                        string         `json:"role_name"`
 	Wins                            sql.NullInt32  `json:"wins"`
 	Losses                          sql.NullInt32  `json:"losses"`
@@ -168,6 +169,7 @@ func (q *Queries) GetStaffs(ctx context.Context, roleName sql.NullString) ([]Get
 			&i.EmergencyContactName,
 			&i.EmergencyContactPhone,
 			&i.EmergencyContactRelationship,
+			&i.LastMobileLoginAt,
 			&i.RoleName,
 			&i.Wins,
 			&i.Losses,

--- a/internal/domains/user/values/user.go
+++ b/internal/domains/user/values/user.go
@@ -24,6 +24,7 @@ type ReadValue struct {
 	EmergencyContactName         *string
 	EmergencyContactPhone        *string
 	EmergencyContactRelationship *string
+	LastMobileLoginAt            *time.Time
 	MembershipInfo               *MembershipReadValue
 	AthleteInfo                  *AthleteReadValue
 }


### PR DESCRIPTION
# ✨ Changes Made

  - Add weekly usage reduction when credits are refunded (credits now "reset" properly)
  - Add `last_mobile_login_at` field to customer API response for mobile usage visibility
  - Fix swagger annotation for mobile analytics endpoint

  ---

  # 🧠 Reason for Changes

  - **Weekly usage fix**: When admin refunds credits, the weekly usage counter should also decrease so the customer can use those credits again within the same week
  - **Mobile login visibility**: Admin panel needs to see when each customer last used the mobile app directly in customer list/details, not just aggregate stats

  ---

  # 🧪 Testing Performed

  - [ ] Frontend tested locally (`npm run dev`)
  - [ ] Mobile App tested via Expo / emulator
  - [x] Backend APIs tested via Postman
  - [ ] No console errors (Frontend)
  - [x] No server errors (Backend)
  - [ ] Mobile app builds successfully (if applicable)

  ---

  # 📸 Screenshots or Screen Recording (Optional)

  N/A - Backend only

  ---

  # 🔗 Related Trello Task

  <!-- Link to the related Trello card -->

  ---

  # 🗒️ Notes for Reviewer (Optional)

  **Credit Refund Behavior Change:**
  - Before: Refund restored credits but weekly usage stayed the same
  - After: Refund restores credits AND reduces weekly usage counter

  **New Customer Response Field:**
  ```json
  {
    "user_id": "...",
    "first_name": "AJ",
    "last_name": "Go",
    "last_mobile_login_at": "2026-01-07T22:33:49.170189Z"
  }

  Files Modified:
  - internal/domains/user/persistence/sqlc/queries/credit.sql - Added ReduceWeeklyCreditsUsed query
  - internal/domains/user/persistence/repositories/customer_credit_repository.go - Added ReduceWeeklyUsage method
  - internal/domains/user/services/customer_credit_service.go - Call reduce weekly usage on refund
  - internal/domains/user/values/user.go - Added LastMobileLoginAt field
  - internal/domains/user/persistence/repository/customer_repository.go - Map mobile login field
  - internal/domains/user/dto/customer/response.go - Added field to response DTO
  - internal/domains/analytics/handler/mobile_analytics_handler.go - Fixed swagger annotation