### PR TITLE
fix: add one-time payment invoice URL retrieval to backfill endpoint

### DIFF
--- a/internal/domains/payment/handler/payment_reports_handler.go
+++ b/internal/domains/payment/handler/payment_reports_handler.go
@@ -485,6 +485,25 @@ func (h *PaymentReportsHandler) BackfillPaymentURLs(w http.ResponseWriter, r *ht
 				log.Printf("[PAYMENT-BACKFILL] Found receipt URL for transaction %s via checkout session", tx.ID)
 			}
 
+			// For one-time payments (credit packages, etc.), get invoice from the charge's invoice
+			if sess.PaymentIntent != nil && sess.PaymentIntent.LatestCharge != nil &&
+				sess.PaymentIntent.LatestCharge.Invoice != nil && sess.PaymentIntent.LatestCharge.Invoice.ID != "" {
+				inv, invErr := invoice.Get(sess.PaymentIntent.LatestCharge.Invoice.ID, nil)
+				if invErr != nil {
+					log.Printf("[PAYMENT-BACKFILL] Error fetching invoice %s for one-time payment: %v", sess.PaymentIntent.LatestCharge.Invoice.ID, invErr)
+				} else {
+					if inv.HostedInvoiceURL != "" {
+						invoiceURL = sql.NullString{String: inv.HostedInvoiceURL, Valid: true}
+					}
+					if inv.InvoicePDF != "" {
+						invoicePDFURL = sql.NullString{String: inv.InvoicePDF, Valid: true}
+					}
+					if invoiceURL.Valid {
+						log.Printf("[PAYMENT-BACKFILL] Found invoice URLs for transaction %s via one-time payment charge", tx.ID)
+					}
+				}
+			}
+
 			// For subscription payments, get invoice from the subscription's latest invoice
 			if sess.Subscription != nil && sess.Subscription.LatestInvoice != nil {
 				if sess.Subscription.LatestInvoice.HostedInvoiceURL != "" {


### PR DESCRIPTION
The backfill endpoint was only checking subscriptions for invoice URLs. For one-time payments (credit packages), invoices come from the charge's invoice field, not from a subscription.

