### PR TITLE
feat: add membership status filter and improve customer search

### DIFF
--- a/internal/domains/user/dto/customer/response.go
+++ b/internal/domains/user/dto/customer/response.go
@@ -35,6 +35,7 @@ type MembershipResponseDto struct {
 	MembershipPlanName    *string    `json:"membership_plan_name,omitempty"`
 	MembershipStartDate   *time.Time `json:"membership_start_date,omitempty"`
 	MembershipRenewalDate *time.Time `json:"membership_renewal_date,omitempty"`
+	Status                *string    `json:"status,omitempty"`
 }
 
 func UserReadValueToResponse(customer values.ReadValue) Response {
@@ -64,6 +65,7 @@ func UserReadValueToResponse(customer values.ReadValue) Response {
 			MembershipRenewalDate: &customer.MembershipInfo.MembershipRenewalDate,
 			MembershipPlanID:      &customer.MembershipInfo.MembershipPlanID,
 			MembershipPlanName:    &customer.MembershipInfo.MembershipPlanName,
+			Status:                &customer.MembershipInfo.Status,
 		}
 	}
 

--- a/internal/domains/user/handler/customer_handler.go
+++ b/internal/domains/user/handler/customer_handler.go
@@ -280,6 +280,18 @@ func (h *CustomersHandler) GetCustomers(w http.ResponseWriter, r *http.Request) 
 		filters.MembershipPlanID = &id
 	}
 
+	// membership_status filter (active, inactive, canceled, expired, past_due)
+	if statusStr := query.Get("membership_status"); statusStr != "" {
+		validStatuses := map[string]bool{
+			"active": true, "inactive": true, "canceled": true, "expired": true, "past_due": true,
+		}
+		if !validStatuses[statusStr] {
+			responseHandlers.RespondWithError(w, errLib.New("Invalid 'membership_status' value, must be one of: active, inactive, canceled, expired, past_due", http.StatusBadRequest))
+			return
+		}
+		filters.MembershipStatus = &statusStr
+	}
+
 	// has_membership filter
 	if hasMembershipStr := query.Get("has_membership"); hasMembershipStr != "" {
 		if hasMembershipStr == "true" {

--- a/internal/domains/user/persistence/repository/customer_repository.go
+++ b/internal/domains/user/persistence/repository/customer_repository.go
@@ -54,6 +54,9 @@ func (r *CustomerRepository) GetCustomers(ctx context.Context, limit, offset int
 	if filters.MembershipPlanID != nil {
 		params.MembershipPlanID = uuid.NullUUID{UUID: *filters.MembershipPlanID, Valid: true}
 	}
+	if filters.MembershipStatus != nil {
+		params.MembershipStatus = sql.NullString{String: *filters.MembershipStatus, Valid: true}
+	}
 	if filters.HasMembership != nil {
 		params.HasMembership = sql.NullBool{Bool: *filters.HasMembership, Valid: true}
 	}
@@ -136,6 +139,7 @@ func (r *CustomerRepository) GetCustomers(ctx context.Context, limit, offset int
 				MembershipName:        dbCustomer.MembershipName.String,
 				MembershipStartDate:   dbCustomer.MembershipStartDate.Time,
 				MembershipRenewalDate: dbCustomer.MembershipPlanRenewalDate.Time,
+				Status:                string(dbCustomer.MembershipStatus.MembershipMembershipStatus),
 			}
 		}
 
@@ -242,6 +246,7 @@ func (r *CustomerRepository) GetCustomer(ctx context.Context, id uuid.UUID, emai
 			MembershipName:        dbCustomer.MembershipName.String,
 			MembershipStartDate:   dbCustomer.MembershipStartDate.Time,
 			MembershipRenewalDate: dbCustomer.MembershipPlanRenewalDate.Time,
+			Status:                string(dbCustomer.MembershipStatus.MembershipMembershipStatus),
 		}
 	}
 
@@ -433,6 +438,9 @@ func (r *CustomerRepository) CountCustomers(ctx context.Context, filters userVal
 	// Set optional filter params
 	if filters.MembershipPlanID != nil {
 		params.MembershipPlanID = uuid.NullUUID{UUID: *filters.MembershipPlanID, Valid: true}
+	}
+	if filters.MembershipStatus != nil {
+		params.MembershipStatus = sql.NullString{String: *filters.MembershipStatus, Valid: true}
 	}
 	if filters.HasMembership != nil {
 		params.HasMembership = sql.NullBool{Bool: *filters.HasMembership, Valid: true}

--- a/internal/domains/user/persistence/sqlc/generated/models.go
+++ b/internal/domains/user/persistence/sqlc/generated/models.go
@@ -326,6 +326,7 @@ const (
 	MembershipMembershipStatusInactive MembershipMembershipStatus = "inactive"
 	MembershipMembershipStatusCanceled MembershipMembershipStatus = "canceled"
 	MembershipMembershipStatusExpired  MembershipMembershipStatus = "expired"
+	MembershipMembershipStatusPastDue  MembershipMembershipStatus = "past_due"
 )
 
 func (e *MembershipMembershipStatus) Scan(src interface{}) error {
@@ -368,7 +369,8 @@ func (e MembershipMembershipStatus) Valid() bool {
 	case MembershipMembershipStatusActive,
 		MembershipMembershipStatusInactive,
 		MembershipMembershipStatusCanceled,
-		MembershipMembershipStatusExpired:
+		MembershipMembershipStatusExpired,
+		MembershipMembershipStatusPastDue:
 		return true
 	}
 	return false
@@ -380,6 +382,7 @@ func AllMembershipMembershipStatusValues() []MembershipMembershipStatus {
 		MembershipMembershipStatusInactive,
 		MembershipMembershipStatusCanceled,
 		MembershipMembershipStatusExpired,
+		MembershipMembershipStatusPastDue,
 	}
 }
 

--- a/internal/domains/user/persistence/sqlc/queries/customer.sql
+++ b/internal/domains/user/persistence/sqlc/queries/customer.sql
@@ -50,16 +50,19 @@ FROM users.users u
 WHERE u.is_archived = FALSE
   AND (u.parent_id = $1 OR $1 IS NULL)
   AND (sqlc.narg('search')::varchar IS NULL
-  OR u.first_name ILIKE sqlc.narg('search') || '%'
-  OR u.last_name ILIKE sqlc.narg('search') || '%'
-  OR u.email ILIKE sqlc.narg('search') || '%'
-  OR u.phone ILIKE sqlc.narg('search') || '%'
-  OR u.notes ILIKE sqlc.narg('search') || '%')
+  OR u.first_name ILIKE '%' || sqlc.narg('search') || '%'
+  OR u.last_name ILIKE '%' || sqlc.narg('search') || '%'
+  OR u.first_name || ' ' || u.last_name ILIKE '%' || sqlc.narg('search') || '%'
+  OR u.email ILIKE '%' || sqlc.narg('search') || '%'
+  OR u.phone ILIKE '%' || sqlc.narg('search') || '%'
+  OR u.notes ILIKE '%' || sqlc.narg('search') || '%')
   AND NOT EXISTS (SELECT 1
                   FROM staff.staff s
                   WHERE s.id = u.id)
   -- membership_plan_id filter
   AND (sqlc.narg('membership_plan_id')::uuid IS NULL OR cmp.membership_plan_id = sqlc.narg('membership_plan_id'))
+  -- membership_status filter
+  AND (sqlc.narg('membership_status')::varchar IS NULL OR cmp.status::text = sqlc.narg('membership_status'))
   -- has_membership filter (active membership exists)
   AND (sqlc.narg('has_membership')::boolean IS NULL
     OR (sqlc.narg('has_membership') = true AND cmp.status = 'active')
@@ -82,6 +85,7 @@ SELECT u.*,
        mp.name          AS membership_plan_name,
        cmp.start_date   AS membership_start_date,
        cmp.renewal_date AS membership_plan_renewal_date,
+       cmp.status       AS membership_status,
        a.points,
        a.wins,
        a.losses,
@@ -144,14 +148,17 @@ FROM users.users u
 WHERE u.is_archived = FALSE
   AND (u.parent_id = $1 OR $1 IS NULL)
   AND (sqlc.narg('search')::varchar IS NULL
-  OR u.first_name ILIKE sqlc.narg('search') || '%'
-  OR u.last_name ILIKE sqlc.narg('search') || '%'
-  OR u.email ILIKE sqlc.narg('search') || '%'
-  OR u.phone ILIKE sqlc.narg('search') || '%'
-  OR u.notes ILIKE sqlc.narg('search') || '%')
+  OR u.first_name ILIKE '%' || sqlc.narg('search') || '%'
+  OR u.last_name ILIKE '%' || sqlc.narg('search') || '%'
+  OR u.first_name || ' ' || u.last_name ILIKE '%' || sqlc.narg('search') || '%'
+  OR u.email ILIKE '%' || sqlc.narg('search') || '%'
+  OR u.phone ILIKE '%' || sqlc.narg('search') || '%'
+  OR u.notes ILIKE '%' || sqlc.narg('search') || '%')
   AND NOT EXISTS (SELECT 1 FROM staff.staff s WHERE s.id = u.id)
   -- membership_plan_id filter
   AND (sqlc.narg('membership_plan_id')::uuid IS NULL OR cmp.membership_plan_id = sqlc.narg('membership_plan_id'))
+  -- membership_status filter
+  AND (sqlc.narg('membership_status')::varchar IS NULL OR cmp.status::text = sqlc.narg('membership_status'))
   -- has_membership filter (active membership exists)
   AND (sqlc.narg('has_membership')::boolean IS NULL
     OR (sqlc.narg('has_membership') = true AND cmp.status = 'active')

--- a/internal/domains/user/values/customer.go
+++ b/internal/domains/user/values/customer.go
@@ -12,6 +12,7 @@ type MembershipReadValue struct {
 	MembershipName        string
 	MembershipStartDate   time.Time
 	MembershipRenewalDate time.Time
+	Status                string
 }
 
 type MembershipPlansReadValue struct {
@@ -89,6 +90,7 @@ type CustomerFilterParams struct {
 	ParentID         uuid.UUID
 	Search           string
 	MembershipPlanID *uuid.UUID
+	MembershipStatus *string
 	HasMembership    *bool
 	HasCredits       *bool
 	MinCredits       *int32


### PR DESCRIPTION
- Add membership_status filter to GET /customers endpoint
  - Supports: active, inactive, canceled, expired, past_due
- Improve search to support:
  - Partial matches (using %search% instead of search%)
  - Full name search (first_name || ' ' || last_name)
- Add status field to membership response DTO
- Update SQL queries (GetCustomers, CountCustomers) with new filters

