### PR TITLE
Fixed only showing one invoice and also fixed not tracking failed payments

### DIFF
--- a/db/migrations/20260121000000_add_unique_stripe_ids_to_payments.sql
+++ b/db/migrations/20260121000000_add_unique_stripe_ids_to_payments.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Add unique constraints to prevent duplicate payment records
+-- Note: PostgreSQL unique constraints allow multiple NULLs, so transactions
+-- without these IDs (e.g., one-time payments without invoices) are unaffected
+
+-- Unique constraint on stripe_invoice_id to prevent duplicate invoice records
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payment_transactions_unique_stripe_invoice
+ON payments.payment_transactions(stripe_invoice_id)
+WHERE stripe_invoice_id IS NOT NULL;
+
+-- Unique constraint on stripe_checkout_session_id to prevent duplicate checkout records
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payment_transactions_unique_stripe_checkout_session
+ON payments.payment_transactions(stripe_checkout_session_id)
+WHERE stripe_checkout_session_id IS NOT NULL;
+
+-- Unique constraint on stripe_payment_intent_id to prevent duplicate payment intent records
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payment_transactions_unique_stripe_payment_intent
+ON payments.payment_transactions(stripe_payment_intent_id)
+WHERE stripe_payment_intent_id IS NOT NULL;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP INDEX IF EXISTS payments.idx_payment_transactions_unique_stripe_payment_intent;
+DROP INDEX IF EXISTS payments.idx_payment_transactions_unique_stripe_checkout_session;
+DROP INDEX IF EXISTS payments.idx_payment_transactions_unique_stripe_invoice;
+
+-- +goose StatementEnd

--- a/internal/domains/payment/services/webhooks.go
+++ b/internal/domains/payment/services/webhooks.go
@@ -1056,6 +1056,9 @@ func (s *WebhookService) HandleInvoicePaymentFailed(ctx context.Context, event s
 
 	log.Printf("[WEBHOOK] Successfully marked subscription %s as past_due for user %s after payment failure %s", subscriptionID, userID, invoice.ID)
 
+	// Track the failed payment in the centralized payment system
+	go s.trackFailedPayment(&invoice, userID, time.Unix(event.Created, 0))
+
 	// Send email notification about payment failure
 	go s.sendPaymentFailureEmail(userID, invoice.ID)
 


### PR DESCRIPTION
 # ✨ Changes Made

  <!-- List what you changed, fixed, or added -->
  - Added invoice backfilling to capture subscription renewals (previously only checkout sessions were backfilled,
  missing recurring payments)
  - Added failed payment tracking - failed payments are now recorded in `payment_transactions` with `payment_status:
  'failed'`
  - Added unique constraints on `stripe_invoice_id`, `stripe_checkout_session_id`, and `stripe_payment_intent_id` to
  prevent duplicate records

  ---

  # 🧠 Reason for Changes

  <!-- Explain why this change was necessary -->

  Users were only seeing one invoice in their payment history because the backfill endpoint only pulled from Stripe
  Checkout Sessions (initial purchases). Subscription renewals come through Stripe Invoices, which weren't being
  captured. Additionally, failed payment attempts weren't being recorded at all, making it difficult to track payment
  issues and understand why users showed as overdue.

  ---

  # 🧪 Testing Performed

  <!-- Confirm what testing was done -->

  - [ ] Frontend tested locally (`npm run dev`)
  - [ ] Mobile App tested via Expo / emulator
  - [x] Backend APIs tested via Postman
  - [ ] No console errors (Frontend)
  - [x] No server errors (Backend)
  - [ ] Mobile app builds successfully (if applicable)

  ---