### PR TITLE
add archived account auto-deletion

### DIFF
--- a/db/migrations/20260129000000_add_archived_at_timestamp.sql
+++ b/db/migrations/20260129000000_add_archived_at_timestamp.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Add archived_at timestamp to track when accounts were archived for auto-deletion
+ALTER TABLE users.users
+ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ;
+
+-- Backfill: set archived_at for already archived accounts (use updated_at as best guess)
+UPDATE users.users
+SET archived_at = updated_at
+WHERE is_archived = TRUE AND archived_at IS NULL;
+
+-- Add index for archived account cleanup queries
+CREATE INDEX IF NOT EXISTS idx_users_archived_at ON users.users(archived_at) WHERE archived_at IS NOT NULL;
+
+COMMENT ON COLUMN users.users.archived_at IS 'Timestamp when account was archived. Archived accounts are permanently deleted after 30 days.';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS users.idx_users_archived_at;
+ALTER TABLE users.users DROP COLUMN IF EXISTS archived_at;
+-- +goose StatementEnd

--- a/internal/domains/user/persistence/repository/customer_repository.go
+++ b/internal/domains/user/persistence/repository/customer_repository.go
@@ -99,6 +99,10 @@ func (r *CustomerRepository) GetCustomers(ctx context.Context, limit, offset int
 			customer.ScheduledDeletionAt = &dbCustomer.ScheduledDeletionAt.Time
 		}
 
+		if dbCustomer.ArchivedAt.Valid {
+			customer.ArchivedAt = &dbCustomer.ArchivedAt.Time
+		}
+
 		if dbCustomer.HubspotID.Valid {
 			customer.HubspotID = &dbCustomer.HubspotID.String
 		}
@@ -208,6 +212,10 @@ func (r *CustomerRepository) GetCustomer(ctx context.Context, id uuid.UUID, emai
 
 	if dbCustomer.ScheduledDeletionAt.Valid {
 		customer.ScheduledDeletionAt = &dbCustomer.ScheduledDeletionAt.Time
+	}
+
+	if dbCustomer.ArchivedAt.Valid {
+		customer.ArchivedAt = &dbCustomer.ArchivedAt.Time
 	}
 
 	if dbCustomer.HubspotID.Valid {
@@ -611,6 +619,9 @@ func (r *CustomerRepository) ListArchivedCustomers(ctx context.Context, limit, o
 			IsArchived:  dbCustomer.IsArchived,
 		}
 
+		if dbCustomer.ArchivedAt.Valid {
+			customers[i].ArchivedAt = &dbCustomer.ArchivedAt.Time
+		}
 		if dbCustomer.HubspotID.Valid {
 			customers[i].HubspotID = &dbCustomer.HubspotID.String
 		}

--- a/internal/domains/user/persistence/sqlc/generated/customer.sql.go
+++ b/internal/domains/user/persistence/sqlc/generated/customer.sql.go
@@ -16,6 +16,7 @@ import (
 const archiveCustomer = `-- name: ArchiveCustomer :execrows
 UPDATE users.users
 SET is_archived = TRUE,
+    archived_at = current_timestamp,
     updated_at = current_timestamp
 WHERE id = $1
 `
@@ -356,7 +357,7 @@ func (q *Queries) GetAthletes(ctx context.Context, arg GetAthletesParams) ([]Get
 }
 
 const getCustomer = `-- name: GetCustomer :one
-SELECT u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, u.last_mobile_login_at, u.pending_email, u.pending_email_token, u.pending_email_token_expires_at, u.email_changed_at,
+SELECT u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, u.last_mobile_login_at, u.pending_email, u.pending_email_token, u.pending_email_token_expires_at, u.email_changed_at, u.archived_at,
        m.name           AS membership_name,
        mp.id            AS membership_plan_id,
        mp.name          AS membership_plan_name,
@@ -430,6 +431,7 @@ type GetCustomerRow struct {
 	PendingEmailToken               sql.NullString                 `json:"pending_email_token"`
 	PendingEmailTokenExpiresAt      sql.NullTime                   `json:"pending_email_token_expires_at"`
 	EmailChangedAt                  sql.NullTime                   `json:"email_changed_at"`
+	ArchivedAt                      sql.NullTime                   `json:"archived_at"`
 	MembershipName                  sql.NullString                 `json:"membership_name"`
 	MembershipPlanID                uuid.NullUUID                  `json:"membership_plan_id"`
 	MembershipPlanName              sql.NullString                 `json:"membership_plan_name"`
@@ -485,6 +487,7 @@ func (q *Queries) GetCustomer(ctx context.Context, arg GetCustomerParams) (GetCu
 		&i.PendingEmailToken,
 		&i.PendingEmailTokenExpiresAt,
 		&i.EmailChangedAt,
+		&i.ArchivedAt,
 		&i.MembershipName,
 		&i.MembershipPlanID,
 		&i.MembershipPlanName,
@@ -503,7 +506,7 @@ func (q *Queries) GetCustomer(ctx context.Context, arg GetCustomerParams) (GetCu
 }
 
 const getCustomers = `-- name: GetCustomers :many
-SELECT u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, u.last_mobile_login_at, u.pending_email, u.pending_email_token, u.pending_email_token_expires_at, u.email_changed_at,
+SELECT u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, u.last_mobile_login_at, u.pending_email, u.pending_email_token, u.pending_email_token_expires_at, u.email_changed_at, u.archived_at,
        m.name           AS membership_name,
        mp.id            AS membership_plan_id,
        mp.name          AS membership_plan_name,
@@ -611,6 +614,7 @@ type GetCustomersRow struct {
 	PendingEmailToken               sql.NullString                 `json:"pending_email_token"`
 	PendingEmailTokenExpiresAt      sql.NullTime                   `json:"pending_email_token_expires_at"`
 	EmailChangedAt                  sql.NullTime                   `json:"email_changed_at"`
+	ArchivedAt                      sql.NullTime                   `json:"archived_at"`
 	MembershipName                  sql.NullString                 `json:"membership_name"`
 	MembershipPlanID                uuid.NullUUID                  `json:"membership_plan_id"`
 	MembershipPlanName              sql.NullString                 `json:"membership_plan_name"`
@@ -684,6 +688,7 @@ func (q *Queries) GetCustomers(ctx context.Context, arg GetCustomersParams) ([]G
 			&i.PendingEmailToken,
 			&i.PendingEmailTokenExpiresAt,
 			&i.EmailChangedAt,
+			&i.ArchivedAt,
 			&i.MembershipName,
 			&i.MembershipPlanID,
 			&i.MembershipPlanName,
@@ -871,7 +876,7 @@ func (q *Queries) GetUserSuspendedMemberships(ctx context.Context, userID uuid.U
 }
 
 const listArchivedCustomers = `-- name: ListArchivedCustomers :many
-SELECT u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, u.last_mobile_login_at, u.pending_email, u.pending_email_token, u.pending_email_token_expires_at, u.email_changed_at
+SELECT u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, u.last_mobile_login_at, u.pending_email, u.pending_email_token, u.pending_email_token_expires_at, u.email_changed_at, u.archived_at
 FROM users.users u
 WHERE u.is_archived = TRUE
 LIMIT $2 OFFSET $1
@@ -928,6 +933,7 @@ func (q *Queries) ListArchivedCustomers(ctx context.Context, arg ListArchivedCus
 			&i.PendingEmailToken,
 			&i.PendingEmailTokenExpiresAt,
 			&i.EmailChangedAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1086,6 +1092,7 @@ func (q *Queries) SuspendUserMemberships(ctx context.Context, arg SuspendUserMem
 const unarchiveCustomer = `-- name: UnarchiveCustomer :execrows
 UPDATE users.users
 SET is_archived = FALSE,
+    archived_at = NULL,
     updated_at = current_timestamp
 WHERE id = $1
 `

--- a/internal/domains/user/persistence/sqlc/generated/models.go
+++ b/internal/domains/user/persistence/sqlc/generated/models.go
@@ -1229,6 +1229,8 @@ type UsersUser struct {
 	PendingEmailTokenExpiresAt sql.NullTime `json:"pending_email_token_expires_at"`
 	// Timestamp when the user last changed their email address.
 	EmailChangedAt sql.NullTime `json:"email_changed_at"`
+	// Timestamp when account was archived. Archived accounts are permanently deleted after 30 days.
+	ArchivedAt sql.NullTime `json:"archived_at"`
 }
 
 // Tracks weekly credit consumption per customer for membership limit enforcement

--- a/internal/domains/user/persistence/sqlc/generated/staff.sql.go
+++ b/internal/domains/user/persistence/sqlc/generated/staff.sql.go
@@ -79,7 +79,7 @@ func (q *Queries) GetAvailableStaffRoles(ctx context.Context) ([]StaffStaffRole,
 }
 
 const getStaffs = `-- name: GetStaffs :many
-SELECT s.is_active, u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, u.last_mobile_login_at, u.pending_email, u.pending_email_token, u.pending_email_token_expires_at, u.email_changed_at, sr.role_name, cs.wins, cs.losses, s.photo_url
+SELECT s.is_active, u.id, u.hubspot_id, u.country_alpha2_code, u.gender, u.first_name, u.last_name, u.parent_id, u.phone, u.email, u.has_marketing_email_consent, u.has_sms_consent, u.created_at, u.updated_at, u.dob, u.is_archived, u.square_customer_id, u.stripe_customer_id, u.notes, u.deleted_at, u.scheduled_deletion_at, u.email_verified, u.email_verification_token, u.email_verification_token_expires_at, u.email_verified_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.suspension_expires_at, u.emergency_contact_name, u.emergency_contact_phone, u.emergency_contact_relationship, u.last_mobile_login_at, u.pending_email, u.pending_email_token, u.pending_email_token_expires_at, u.email_changed_at, u.archived_at, sr.role_name, cs.wins, cs.losses, s.photo_url
 FROM staff.staff s
 JOIN users.users u ON u.id = s.id
 JOIN staff.staff_roles sr ON s.role_id = sr.id
@@ -125,6 +125,7 @@ type GetStaffsRow struct {
 	PendingEmailToken               sql.NullString `json:"pending_email_token"`
 	PendingEmailTokenExpiresAt      sql.NullTime   `json:"pending_email_token_expires_at"`
 	EmailChangedAt                  sql.NullTime   `json:"email_changed_at"`
+	ArchivedAt                      sql.NullTime   `json:"archived_at"`
 	RoleName                        string         `json:"role_name"`
 	Wins                            sql.NullInt32  `json:"wins"`
 	Losses                          sql.NullInt32  `json:"losses"`
@@ -178,6 +179,7 @@ func (q *Queries) GetStaffs(ctx context.Context, roleName sql.NullString) ([]Get
 			&i.PendingEmailToken,
 			&i.PendingEmailTokenExpiresAt,
 			&i.EmailChangedAt,
+			&i.ArchivedAt,
 			&i.RoleName,
 			&i.Wins,
 			&i.Losses,

--- a/internal/domains/user/persistence/sqlc/queries/customer.sql
+++ b/internal/domains/user/persistence/sqlc/queries/customer.sql
@@ -222,12 +222,14 @@ ORDER BY cmp.start_date DESC;
 -- name: ArchiveCustomer :execrows
 UPDATE users.users
 SET is_archived = TRUE,
+    archived_at = current_timestamp,
     updated_at = current_timestamp
 WHERE id = sqlc.arg('id');
 
 -- name: UnarchiveCustomer :execrows
 UPDATE users.users
 SET is_archived = FALSE,
+    archived_at = NULL,
     updated_at = current_timestamp
 WHERE id = sqlc.arg('id');
 

--- a/internal/domains/user/values/user.go
+++ b/internal/domains/user/values/user.go
@@ -19,6 +19,7 @@ type ReadValue struct {
 	CreatedAt                    time.Time
 	UpdatedAt                    time.Time
 	IsArchived                   bool
+	ArchivedAt                   *time.Time
 	DeletedAt                    *time.Time
 	ScheduledDeletionAt          *time.Time
 	EmergencyContactName         *string


### PR DESCRIPTION
  Account Deletion Fixes:
  - Add archived_at timestamp column to track when accounts are archived
  - Auto-delete archived accounts after 30 days
  - Add days_until_deletion countdown to customer response for both soft-deleted and archived accounts

  Migration Workflow:
  - Add workflow_dispatch for manual trigger capability
