### PR TITLE
  Remove child/parent JWT roles - all customers are athletes

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -477,7 +477,7 @@ func RegisterAuthRoutes(container *di.Container) func(chi.Router) {
 
 	return func(r chi.Router) {
 		r.Post("/", h.Login)
-		r.With(middlewares.JWTAuthMiddleware(true)).Post("/child/{id}", h.LoginAsChild)
+		r.With(middlewares.JWTAuthMiddleware(true)).Post("/linked/{id}", h.LoginAsChild)
 
 		// Email verification routes (public endpoints)
 		r.Post("/verify-email", verificationHandler.VerifyEmail)

--- a/db/migrations/20260219000000_remove_child_parent_roles.sql
+++ b/db/migrations/20260219000000_remove_child_parent_roles.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Convert all child account_types to athlete
+UPDATE users.users SET account_type = 'athlete' WHERE account_type = 'child';
+
+-- Insert athlete records for users with parent_id who don't have one yet
+INSERT INTO athletic.athletes (id)
+SELECT u.id FROM users.users u
+LEFT JOIN athletic.athletes a ON a.id = u.id
+WHERE u.parent_id IS NOT NULL AND a.id IS NULL;
+
+-- Insert athlete records for users with account_type = 'parent' who don't have one yet
+INSERT INTO athletic.athletes (id)
+SELECT u.id FROM users.users u
+LEFT JOIN athletic.athletes a ON a.id = u.id
+WHERE u.account_type = 'parent' AND a.id IS NULL;
+
+-- Update existing initiated_by = 'child' rows to 'athlete'
+UPDATE users.parent_link_requests SET initiated_by = 'athlete' WHERE initiated_by = 'child';
+
+-- Update CHECK constraint on parent_link_requests.initiated_by
+ALTER TABLE users.parent_link_requests DROP CONSTRAINT IF EXISTS parent_link_requests_initiated_by_check;
+ALTER TABLE users.parent_link_requests ADD CONSTRAINT parent_link_requests_initiated_by_check
+    CHECK (initiated_by IN ('athlete', 'parent'));
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Revert CHECK constraint
+ALTER TABLE users.parent_link_requests DROP CONSTRAINT IF EXISTS parent_link_requests_initiated_by_check;
+ALTER TABLE users.parent_link_requests ADD CONSTRAINT parent_link_requests_initiated_by_check
+    CHECK (initiated_by IN ('child', 'parent'));
+
+-- Revert initiated_by back to 'child'
+UPDATE users.parent_link_requests SET initiated_by = 'child' WHERE initiated_by = 'athlete';
+
+-- Note: We don't remove athlete records or revert account_type in down migration
+-- as that could cause data loss for legitimately created athlete records.
+
+-- +goose StatementEnd

--- a/internal/domains/family/service/service.go
+++ b/internal/domains/family/service/service.go
@@ -97,7 +97,7 @@ func (s *Service) RequestLink(ctx context.Context, targetEmail string) (*dto.Req
 		// Caller is a child (has a parent) - they want to link to a new parent
 		childID = caller.ID
 		newParentID = target.ID
-		initiatedBy = "child"
+		initiatedBy = "athlete"
 
 		// Check if target is also a child (has a parent)
 		if target.ParentID.Valid {
@@ -182,7 +182,7 @@ func (s *Service) RequestLink(ctx context.Context, targetEmail string) (*dto.Req
 	}
 
 	if childErr == nil && parentErr == nil {
-		if initiatedBy == "child" {
+		if initiatedBy == "athlete" {
 			// Child initiated - send code to new parent
 			if newParent.Email.Valid {
 				go email.SendParentLinkRequestEmail(
@@ -222,7 +222,7 @@ func (s *Service) RequestLink(ctx context.Context, targetEmail string) (*dto.Req
 	}
 
 	var message string
-	if initiatedBy == "child" {
+	if initiatedBy == "athlete" {
 		message = fmt.Sprintf("Verification code sent to %s", targetEmail)
 	} else {
 		message = fmt.Sprintf("Verification code sent to child at %s", targetEmail)
@@ -266,7 +266,7 @@ func (s *Service) ConfirmLink(ctx context.Context, code string) (*dto.ConfirmLin
 		}
 	} else {
 		// Primary verification
-		if request.InitiatedBy == "child" {
+		if request.InitiatedBy == "athlete" {
 			// Parent should be verifying
 			if request.NewParentID != callerID {
 				return nil, errLib.New("This verification code is not for you", http.StatusForbidden)
@@ -425,7 +425,7 @@ func (s *Service) GetPendingRequests(ctx context.Context) ([]dto.PendingRequestR
 		} else if req.NewParentID == callerID {
 			userRole = "new_parent"
 			// New parent awaits action if child initiated and not yet verified
-			awaitingAction = req.InitiatedBy == "child" && !req.VerifiedAt.Valid
+			awaitingAction = req.InitiatedBy == "athlete" && !req.VerifiedAt.Valid
 		} else if req.OldParentID.Valid && req.OldParentID.UUID == callerID {
 			userRole = "old_parent"
 			// Old parent awaits action if not yet verified

--- a/internal/domains/identity/handler/authentication/authentication_handler.go
+++ b/internal/domains/identity/handler/authentication/authentication_handler.go
@@ -58,17 +58,17 @@ func (h *Handlers) Login(w http.ResponseWriter, r *http.Request) {
 }
 
 // LoginAsChild authenticates a user and returns a JWT token.
-// @Summary Authenticate a user and return a JWT token
-// @Description Authenticates a user using Firebase token and returns a JWT token for the authenticated user
+// @Summary Authenticate as a linked user
+// @Description Authenticates a parent user and returns a JWT token for a linked user
 // @Tags authentication
 // @Accept json
 // @Produce json
 // @Security Bearer
-// @Param id path string true "Child ID"
+// @Param id path string true "Linked user ID"
 // @Success 200 {object} dto.UserAuthenticationResponseDto "User authenticated successfully"
 // @Failure 400 {object} map[string]interface{} "Bad Request: Invalid Firebase token"
 // @Failure 500 {object} map[string]interface{} "Internal Server Error"
-// @Router /auth/child/{id} [post]
+// @Router /auth/linked/{id} [post]
 func (h *Handlers) LoginAsChild(w http.ResponseWriter, r *http.Request) {
 
 	childIdStr := chi.URLParam(r, "id")

--- a/internal/domains/identity/service/authentication/authentication.go
+++ b/internal/domains/identity/service/authentication/authentication.go
@@ -62,7 +62,7 @@ func (s *Service) AuthenticateUser(ctx context.Context, idToken string) (string,
 	}
 
 	// Check if email is verified (except for staff who may have been manually created)
-	if userInfo.Role == "customer" || userInfo.Role == "athlete" || userInfo.Role == "parent" {
+	if userInfo.Role == "customer" || userInfo.Role == "athlete" {
 		isVerified, verifyErr := s.VerificationService.IsEmailVerified(ctx, userInfo.ID)
 		if verifyErr != nil {
 			log.Printf("Failed to check email verification status for user %s: %v", userInfo.ID, verifyErr)
@@ -111,7 +111,7 @@ func (s *Service) AuthenticateChild(ctx context.Context, childId, parentID uuid.
 	if isConnected, err := s.UserRepo.GetIsActualParentChild(ctx, childId, parentID); err != nil {
 		return "", userInfo, err
 	} else if !isConnected {
-		return "", userInfo, errLib.New("child is not associated with the parent", http.StatusNotFound)
+		return "", userInfo, errLib.New("user is not associated with the parent", http.StatusNotFound)
 	}
 
 	userInfo, err := s.UserRepo.GetUserInfo(ctx, "", childId)

--- a/internal/domains/upload/handler/upload_handler.go
+++ b/internal/domains/upload/handler/upload_handler.go
@@ -114,10 +114,6 @@ func (h *UploadHandler) UploadImage(w http.ResponseWriter, r *http.Request) {
 				roleFolder = "staff"
 			case "athlete":
 				roleFolder = "athletes"
-			case "parent":
-				roleFolder = "parents"
-			case "child":
-				roleFolder = "children"
 			default:
 				roleFolder = "users" // fallback for unknown roles
 			}

--- a/internal/middlewares/jwt_auth.go
+++ b/internal/middlewares/jwt_auth.go
@@ -112,10 +112,8 @@ func extractRole(userRoleInfo *jwtLib.RoleInfo) (contextUtils.CtxRole, *errLib.C
 		contextUtils.RoleCoach,
 		contextUtils.RoleSuperAdmin,
 		contextUtils.RoleIT,
-		contextUtils.RoleParent,
 		contextUtils.RoleBarber,
 		contextUtils.RoleAthlete,
-		contextUtils.RoleChild,
 		contextUtils.RoleReceptionist,
 	}
 

--- a/utils/context/context.go
+++ b/utils/context/context.go
@@ -21,8 +21,6 @@ const (
 	RoleIT           CtxRole = "IT"
 	RoleAdmin        CtxRole = "ADMIN"
 	RoleInstructor   CtxRole = "INSTRUCTOR"
-	RoleParent       CtxRole = "PARENT"
-	RoleChild        CtxRole = "CHILD"
 	RoleAthlete      CtxRole = "ATHLETE"
 	RoleCoach        CtxRole = "COACH"
 	RoleBarber       CtxRole = "BARBER"


### PR DESCRIPTION
✨ Changes Made

  - Removed RoleChild and RoleParent JWT role constants from middleware and context
  - Simplified setUserRole to return athlete for all customers (staff check, athlete record, fallback)
  - CreateChildTx and CreateParentTx now create athlete records on registration
  - Renamed /auth/child/{id} to /auth/linked/{id} with updated swagger docs
  - Family service uses initiated_by=athlete instead of child for link requests
  - Removed parent/child cases from upload handler folder mapping
  - Added migration to convert existing child/parent data to athlete records and update CHECK constraint

  ---
  🧠 Reason for Changes

  The role system is being simplified. Previously there were three customer roles (Parent, Athlete, Child) which added
  unnecessary complexity. Now every customer is an athlete with an athlete record and gets role=athlete in their JWT.
  Parent is a relationship tracked via parent_id in the database, not a JWT role. Children are just athletes with a
  parent_id set. This allows parents to enroll themselves in memberships/events and removes role-based logic that should
   be relationship-based.

  ---
  🧪 Testing Performed

  - Frontend tested locally (npm run dev)
  - Mobile App tested via Expo / emulator
  - Backend APIs tested via Postman
  - No console errors (Frontend)
  - No server errors (Backend)
  - Mobile app builds successfully (if applicable)

  ---
  📸 Screenshots or Screen Recording (Optional)

  ---
  🔗 Related Trello Task

  ---
  🗒️ Notes for Reviewer (Optional)

  - Existing users with role=parent or role=child in their JWT will get 401 until they re-login (tokens expire in 24h).
  On re-login they get role=athlete automatically.
  - Migration must run before or alongside deploy. It converts account_type=child to athlete, backfills missing athlete
  records for parents and children, and updates the initiated_by CHECK constraint on parent_link_requests.
  - Family DTOs still use child/new_parent/old_parent as relationship descriptors in responses - these describe the
  users role in the link request, not their JWT role.
  - The /register/child endpoint and family routes are unchanged since they describe relationships not roles.