### PR TITLE
Fixed Membership Response Query

### DIFF
--- a/internal/domains/user/handler/customer_handler.go
+++ b/internal/domains/user/handler/customer_handler.go
@@ -411,6 +411,12 @@ func (h *CustomersHandler) GetCustomerByID(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Fetch all active memberships for this customer
+	memberships, membErr := h.CustomerRepo.GetActiveCustomerMemberships(r.Context(), id)
+	if membErr == nil && len(memberships) > 0 {
+		customer.Memberships = memberships
+	}
+
 	response := customerDto.UserReadValueToResponse(customer)
 
 	responseHandlers.RespondWithSuccess(w, response, http.StatusOK)
@@ -432,6 +438,12 @@ func (h *CustomersHandler) GetCustomerByEmail(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		responseHandlers.RespondWithError(w, err)
 		return
+	}
+
+	// Fetch all active memberships for this customer
+	memberships, membErr := h.CustomerRepo.GetActiveCustomerMemberships(r.Context(), customer.ID)
+	if membErr == nil && len(memberships) > 0 {
+		customer.Memberships = memberships
 	}
 
 	response := customerDto.UserReadValueToResponse(customer)

--- a/internal/domains/user/values/user.go
+++ b/internal/domains/user/values/user.go
@@ -27,7 +27,7 @@ type ReadValue struct {
 	EmergencyContactRelationship *string
 	LastMobileLoginAt            *time.Time
 	PendingEmail                 *string
-	MembershipInfo               *MembershipReadValue
+	Memberships                  []MembershipReadValue
 	AthleteInfo                  *AthleteReadValue
 }
 


### PR DESCRIPTION
✨ Changes Made

  - Added GetActiveCustomerMemberships SQL query to return all active memberships for a customer
  - Changed single-customer endpoints (GetCustomerByID, GetCustomerByEmail) to return all active memberships in a
  memberships array
  - Kept membership_info in the response for backwards compatibility (populated from primary membership)
  - Customer list endpoint unchanged — still returns primary membership per customer

  ---
  🧠 Reason for Changes

  When a customer has multiple active memberships, the backend only returned the most recent one. The frontend already
  supports a memberships array, so the backend needed to return all active memberships for single-customer views.

  ---
  🧪 Testing Performed

  - Frontend tested locally (npm run dev)
  - Mobile App tested via Expo / emulator
  - Backend APIs tested via Postman
  - No console errors (Frontend)
  - No server errors (Backend)
  - Mobile app builds successfully (if applicable)

  ---
  📸 Screenshots or Screen Recording (Optional)

  ---
  🔗 Related Trello Task

  ---
  🗒️ Notes for Reviewer (Optional)

  - Fully backwards compatible — membership_info still returned in the same shape as before
  - New memberships array is additive and uses omitempty, so customers with no memberships see no change
  - Only single-customer endpoints (/customers/id/{id}, /customers/email/{email}) make the extra DB call; the list
  endpoint is unchanged for performance
  - go build ./... passes clean