### PR TITLE
feat(family): Add parent and siblings endpoints for child users

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -913,6 +913,8 @@ func RegisterFamilyRoutes(container *di.Container) func(chi.Router) {
 
 		// Parent routes - authenticated users only
 		r.With(middlewares.JWTAuthMiddleware(true)).Get("/children", h.GetChildren)
+		r.With(middlewares.JWTAuthMiddleware(true)).Get("/parent", h.GetParent)
+		r.With(middlewares.JWTAuthMiddleware(true)).Get("/siblings", h.GetSiblings)
 
 		// Admin routes - admin only for unlinking
 		r.With(middlewares.JWTAuthMiddleware(false, contextUtils.RoleAdmin, contextUtils.RoleSuperAdmin, contextUtils.RoleIT)).Delete("/admin/link/{id}", h.AdminUnlink)

--- a/internal/domains/family/dto/response.go
+++ b/internal/domains/family/dto/response.go
@@ -30,6 +30,22 @@ type ChildResponse struct {
 	LinkedAt  time.Time `json:"linked_at"`
 }
 
+// ParentResponse represents a parent in the child's view
+type ParentResponse struct {
+	ID        uuid.UUID `json:"id"`
+	FirstName string    `json:"first_name"`
+	LastName  string    `json:"last_name"`
+	Email     string    `json:"email,omitempty"`
+}
+
+// SiblingResponse represents a sibling in the child's view
+type SiblingResponse struct {
+	ID        uuid.UUID `json:"id"`
+	FirstName string    `json:"first_name"`
+	LastName  string    `json:"last_name"`
+	Email     string    `json:"email,omitempty"`
+}
+
 // PendingRequestResponse represents a pending link request
 type PendingRequestResponse struct {
 	ID                   uuid.UUID  `json:"id"`

--- a/internal/domains/family/handler/handler.go
+++ b/internal/domains/family/handler/handler.go
@@ -144,6 +144,43 @@ func (h *Handler) GetChildren(w http.ResponseWriter, r *http.Request) {
 	responseHandlers.RespondWithSuccess(w, children, http.StatusOK)
 }
 
+// GetParent gets the parent for the authenticated child user.
+// @Summary Get parent
+// @Description Gets the parent information for the authenticated child user
+// @Tags family
+// @Produce json
+// @Success 200 {object} dto.ParentResponse "Parent information"
+// @Failure 401 {object} map[string]interface{} "Unauthorized"
+// @Failure 404 {object} map[string]interface{} "No parent link found"
+// @Router /family/parent [get]
+func (h *Handler) GetParent(w http.ResponseWriter, r *http.Request) {
+	parent, err := h.Service.GetParent(r.Context())
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	responseHandlers.RespondWithSuccess(w, parent, http.StatusOK)
+}
+
+// GetSiblings gets all siblings for the authenticated child user.
+// @Summary Get siblings
+// @Description Gets all siblings (other children of the same parent) for the authenticated child user
+// @Tags family
+// @Produce json
+// @Success 200 {array} dto.SiblingResponse "Siblings list (empty if no siblings or no parent link)"
+// @Failure 401 {object} map[string]interface{} "Unauthorized"
+// @Router /family/siblings [get]
+func (h *Handler) GetSiblings(w http.ResponseWriter, r *http.Request) {
+	siblings, err := h.Service.GetSiblings(r.Context())
+	if err != nil {
+		responseHandlers.RespondWithError(w, err)
+		return
+	}
+
+	responseHandlers.RespondWithSuccess(w, siblings, http.StatusOK)
+}
+
 // AdminUnlink removes a parent-child link (admin only).
 // @Summary Admin unlink parent-child
 // @Description Removes the parent-child link for a user (admin only)


### PR DESCRIPTION
## Summary

Adds two new GET endpoints to the family domain that allow child users to view their parent and siblings. This enables children to see their family structure in the mobile app without requiring database migrations.

## Changes

### New DTOs (`internal/domains/family/dto/response.go`)
- **ParentResponse**: Represents parent in child's view
- **SiblingResponse**: Represents sibling in child's view
- Both follow existing `ChildResponse` pattern with minimal fields (id, first_name, last_name, email)

### New Service Methods (`internal/domains/family/service/service.go`)
- **GetParent()**: Returns parent info for authenticated child user
  - Validates user has `parent_id` set
  - Returns 404 if no parent link exists
  - Reuses `GetUserById()` repository method
  
- **GetSiblings()**: Returns siblings for authenticated child user
  - Checks if user has `parent_id` set
  - Gets all children with same parent
  - Filters out self from results
  - Returns empty array if no parent link (graceful handling)
  - Reuses `GetChildrenByParentId()` repository method

### New HTTP Handlers (`internal/domains/family/handler/handler.go`)
- **GetParent()**: HTTP handler for parent endpoint
- **GetSiblings()**: HTTP handler for siblings endpoint
- Both include Swagger documentation
- Follow existing handler patterns with proper error handling

### Route Registration (`cmd/server/router/router.go`)
- `GET /family/parent` - authenticated users only
- `GET /family/siblings` - authenticated users only
- Both use JWT authentication middleware

## Database Impact

✅ **No migrations required**
- Uses existing `parent_id` field in users table
- Reuses existing SQLC-generated queries (`GetUserById`, `GetChildrenByParentId`)

## Testing

### Manual Testing
```bash
# Test as child user with parent
curl -X GET http://localhost:8080/family/parent \
  -H "Authorization: Bearer <CHILD_TOKEN>"
# Expected: 200 OK with parent data

# Test as parent user (should fail)
curl -X GET http://localhost:8080/family/parent \
  -H "Authorization: Bearer <PARENT_TOKEN>"
# Expected: 404 Not Found

# Test siblings endpoint
curl -X GET http://localhost:8080/family/siblings \
  -H "Authorization: Bearer <CHILD_TOKEN>"
# Expected: 200 OK with siblings array (empty if no siblings)
```

### Test Scenarios
- ✅ Child user with parent → Returns parent data
- ✅ Child user with siblings → Returns siblings array (excluding self)
- ✅ Child user with no siblings → Returns empty array
- ✅ Parent user trying to get parent → Returns 404
- ✅ User with no parent_id → Returns 404 or empty array (graceful)
- ✅ Authentication required → 401 if no valid JWT

## API Documentation

### GET /family/parent
Returns parent information for authenticated child user.

**Response 200**:
```json
{
  "id": "uuid",
  "first_name": "John",
  "last_name": "Doe",
  "email": "john@example.com"
}
```

**Response 404**: User has no parent link

### GET /family/siblings
Returns siblings for authenticated child user.

**Response 200**:
```json
[
  {
    "id": "uuid",
    "first_name": "Jane",
    "last_name": "Doe",
    "email": "jane@example.com"
  }
]
```

## Implementation Notes

- No new SQL queries needed - reuses existing repository methods
- Error handling follows existing patterns
- Swagger documentation included for both endpoints
- Parent and sibling DTOs expose minimal data (no sensitive fields like parent_id)
- Graceful handling of edge cases (no parent, no siblings)

## Related

This backend work enables the mobile app to display family structure to child users. Mobile app PR will follow separately.

## Checklist

- [x] No database migrations required
- [x] Swagger documentation added
- [x] Follows existing code patterns
- [x] Error handling implemented
- [x] Reuses existing repository methods
- [x] Routes registered with JWT auth
- [x] Manual testing performed

---

🤖 Generated with Claude Code