### PR TITLE
Fix duplicate payment tracking on initial subscription and show real amount on failed payments

### DIFF
--- a/db/migrations/20260312000000_fix_failed_payment_constraint.sql
+++ b/db/migrations/20260312000000_fix_failed_payment_constraint.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Relax the payment calculation constraint to allow failed payments to store
+-- the actual attempted amount. For failed payments, customer_paid is 0 but
+-- original_amount should reflect what was attempted.
+-- Old constraint: customer_paid = original_amount - discount_amount - subsidy_amount
+-- New constraint: same rule, but only enforced for non-failed payments.
+ALTER TABLE payments.payment_transactions DROP CONSTRAINT valid_payment_calculation;
+
+ALTER TABLE payments.payment_transactions ADD CONSTRAINT valid_payment_calculation CHECK (
+    payment_status = 'failed' OR customer_paid = original_amount - discount_amount - subsidy_amount
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE payments.payment_transactions DROP CONSTRAINT valid_payment_calculation;
+
+ALTER TABLE payments.payment_transactions ADD CONSTRAINT valid_payment_calculation CHECK (
+    customer_paid = original_amount - discount_amount - subsidy_amount
+);
+
+-- +goose StatementEnd

--- a/internal/domains/payment/services/payment_tracking_helpers.go
+++ b/internal/domains/payment/services/payment_tracking_helpers.go
@@ -299,9 +299,7 @@ func (s *WebhookService) trackFailedPayment(invoice *stripe.Invoice, customerID 
 		}
 	}
 
-	// For failed payments, set all amounts to 0 to satisfy the constraint:
-	// customer_paid = original_amount - discount_amount - subsidy_amount
-	// Store the attempted amount in metadata for reference
+	// Store the actual attempted amount so the UI shows what was attempted
 	attemptedAmount := float64(invoice.Total) / 100.0
 
 	var subscriptionID string
@@ -315,7 +313,7 @@ func (s *WebhookService) trackFailedPayment(invoice *stripe.Invoice, customerID 
 		CustomerName:         customerName,
 		TransactionType:      "membership_renewal",
 		TransactionDate:      transactionDate,
-		OriginalAmount:       0, // Set to 0 for failed payments (constraint requires customer_paid = original - discount - subsidy)
+		OriginalAmount:       attemptedAmount,
 		DiscountAmount:       0,
 		SubsidyAmount:        0,
 		CustomerPaid:         0, // Payment failed, nothing was collected
@@ -326,10 +324,6 @@ func (s *WebhookService) trackFailedPayment(invoice *stripe.Invoice, customerID 
 		PaymentStatus:        "failed",
 		Currency:             string(invoice.Currency),
 		Description:          fmt.Sprintf("Failed payment attempt - $%.2f was attempted", attemptedAmount),
-		Metadata: map[string]interface{}{
-			"attempted_amount": attemptedAmount,
-			"failure_reason":   "Payment failed",
-		},
 	})
 
 	if trackingErr != nil {

--- a/internal/domains/payment/services/webhooks.go
+++ b/internal/domains/payment/services/webhooks.go
@@ -990,8 +990,14 @@ func (s *WebhookService) HandleInvoicePaymentSucceeded(ctx context.Context, even
 
 	log.Printf("[WEBHOOK] Successfully activated membership for user %s after invoice payment %s", userID, invoice.ID)
 
-	// Track payment in centralized system
-	go s.trackMembershipRenewal(&invoice, userID, time.Unix(event.Created, 0))
+	// Track payment in centralized system — but skip the initial subscription invoice
+	// because checkout.session.completed already tracks that via trackMembershipSubscription.
+	// Only track actual renewals to avoid duplicate payment records.
+	if invoice.BillingReason != stripe.InvoiceBillingReasonSubscriptionCreate {
+		go s.trackMembershipRenewal(&invoice, userID, time.Unix(event.Created, 0))
+	} else {
+		log.Printf("[WEBHOOK] Skipping payment tracking for initial subscription invoice %s (already tracked by checkout)", invoice.ID)
+	}
 
 	// Mark as complete
 	s.Idempotency.MarkEventComplete(event.ID)

--- a/internal/domains/payment/tracking/payment_tracking.go
+++ b/internal/domains/payment/tracking/payment_tracking.go
@@ -75,11 +75,13 @@ type TrackPaymentParams struct {
 
 // TrackPayment creates a new payment transaction record
 func (s *PaymentTrackingService) TrackPayment(ctx context.Context, params TrackPaymentParams) (*db.PaymentsPaymentTransaction, error) {
-	// Validate payment calculation
-	expectedCustomerPaid := params.OriginalAmount - params.DiscountAmount - params.SubsidyAmount
-	if params.CustomerPaid != expectedCustomerPaid {
-		return nil, fmt.Errorf("invalid payment calculation: customer_paid (%.2f) != original (%.2f) - discount (%.2f) - subsidy (%.2f)",
-			params.CustomerPaid, params.OriginalAmount, params.DiscountAmount, params.SubsidyAmount)
+	// Validate payment calculation (skip for failed payments where customer_paid is 0)
+	if params.PaymentStatus != "failed" {
+		expectedCustomerPaid := params.OriginalAmount - params.DiscountAmount - params.SubsidyAmount
+		if params.CustomerPaid != expectedCustomerPaid {
+			return nil, fmt.Errorf("invalid payment calculation: customer_paid (%.2f) != original (%.2f) - discount (%.2f) - subsidy (%.2f)",
+				params.CustomerPaid, params.OriginalAmount, params.DiscountAmount, params.SubsidyAmount)
+		}
 	}
 
 	// Convert metadata to JSONB


### PR DESCRIPTION
  ✨ Changes Made

  - Skip tracking initial subscription invoice in HandleInvoicePaymentSucceeded when BillingReason ==
  subscription_create (already tracked by checkout.session.completed)
  - Store actual attempted amount for failed payments instead of $0 in trackFailedPayment
  - Skip app-level payment calculation validation for failed payments in TrackPayment
  - Add DB migration to relax valid_payment_calculation constraint so failed payments can have original_amount >
  customer_paid

  ---
  🧠 Reason for Changes

  Payment history UI was showing incorrect data:
  1. Duplicate entries — Initial membership purchase appeared twice ($245.18 x2) because both checkout.session.completed
   and invoice.payment_succeeded webhooks were independently tracking the same payment
  2. $0.00 on failed payments — Failed payment attempts displayed as $0.00 instead of the real attempted amount
  ($108.68), making it impossible for staff to see what was actually attempted

  These are display/tracking only changes. No changes to checkout flow, Stripe integration, enrollment logic, or
  billing.

  ---
  🧪 Testing Performed

  - Frontend tested locally (npm run dev)
  - Mobile App tested via Expo / emulator
  - Backend APIs tested via Postman
  - No console errors (Frontend)
  - No server errors (Backend)
  - Mobile app builds successfully (if applicable)

  ---
  📸 Screenshots or Screen Recording (Optional)

  N/A — Backend only change. Payment history UI will reflect correct data after deploy.

  ---
  🔗 Related Trello Task

  N/A — Reported by Mostapha via Slack (payment history showing duplicate charges and $0 failed payments)

  ---
  🗒️ Notes for Reviewer (Optional)

  - Migration required — 20260312000000_fix_failed_payment_constraint.sql relaxes the valid_payment_calculation CHECK
  constraint to exempt failed payments (payment_status = 'failed')
  - Existing bad data not cleaned up — The duplicate and $0 records already in the DB will remain. This fix only applies
   to future payments. Old data can be cleaned up manually per customer as needed.
  - Files changed: webhooks.go, payment_tracking_helpers.go, payment_tracking.go, + new migration
  - Zero risk to billing — payment_transactions is a reporting table only. No other part of the app reads it to make
  enrollment or billing decisions.